### PR TITLE
Add search functionality to QTerminal

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -44,6 +44,8 @@
 #define COPY_SELECTION "Copy Selection"
 #define PASTE_SELECTION "Paste Selection"
 
+#define FIND "Find"
+
 /* Some defaults for QTerminal application */
 
 #define DEFAULT_WIDTH                  800
@@ -63,6 +65,7 @@
 #else
 #define COPY_SELECTION_SHORTCUT      "Ctrl+Shift+C"
 #define PASTE_SELECTION_SHORTCUT      "Ctrl+Shift+V"
+#define FIND_SHORTCUT                 "Ctrl+Shift+F"
 #endif
 
 #define MOVE_LEFT_SHORTCUT             "Shift+Alt+Left"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -208,6 +208,14 @@ void MainWindow::setup_ActionsMenu_Actions()
     seq = QKeySequence::fromString( settings.value(PASTE_SELECTION, PASTE_SELECTION_SHORTCUT).toString() );
     Properties::Instance()->actions[PASTE_SELECTION]->setShortcut(seq);
 
+    menu_Actions->addSeparator();
+
+    Properties::Instance()->actions[FIND] = new QAction(tr("Find..."), this);
+    seq = QKeySequence::fromString( settings.value(FIND, FIND_SHORTCUT).toString() );
+    Properties::Instance()->actions[FIND]->setShortcut(seq);
+    connect(Properties::Instance()->actions[FIND], SIGNAL(triggered()), this, SLOT(find()));
+    menu_Actions->addAction(Properties::Instance()->actions[FIND]);
+
 #if 0
     act = new QAction(this);
     act->setSeparator(true);
@@ -457,6 +465,13 @@ void MainWindow::setKeepOpen(bool value)
 
     m_dropLockButton->setChecked(value);
 }
+
+void MainWindow::find()
+{
+    // A bit ugly perhaps with 4 levels of indirection... 
+    consoleTabulator->terminalHolder()->currentTerminal()->impl()->toggleShowSearchBar();
+}
+
 
 bool MainWindow::event(QEvent *event)
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -53,6 +53,7 @@ protected slots:
 
     void showHide();
     void setKeepOpen(bool value);
+    void find();
 
 protected:
      bool event(QEvent* event);


### PR DESCRIPTION
This commit adds search functionality to QTerminal. It depends on search functionality in qtermwidget (commit 4f9e1c4a060334d, pull request 'search functionality')

This commit adds a 'Find..' entry to the actions menu. Clicking that (or hitting Ctrl-Shift-Find) shows a search bar below the current terminal. 

This should fix issue #9
