### PR TITLE
Fix some glitches in shortcuts and split-handling

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,8 @@
 #define DEFAULT_HEIGHT                 600
 
 // ACTIONS
+#define ADD_TAB_SHORTCUT               "Ctrl+Shift+T"
+#define CLOSE_TAB_SHORTCUT             "Ctrl+Shift+W"
 #define CLEAR_TERMINAL_SHORTCUT        "Ctrl+Shift+X"
 #define TAB_PREV_SHORTCUT	       "Shift+Left"
 #define TAB_NEXT_SHORTCUT	       "Shift+Right"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -284,13 +284,13 @@ void MainWindow::setup_FileMenu_Actions()
     QKeySequence seq;
 
     Properties::Instance()->actions[ADD_TAB] = new QAction(QIcon(":/icons/list-add.png"), tr("New Tab"), this);
-    seq = QKeySequence::fromString( settings.value(ADD_TAB, QKeySequence(QKeySequence::AddTab).toString()).toString() );
+    seq = QKeySequence::fromString( settings.value(ADD_TAB, ADD_TAB_SHORTCUT).toString() );
     Properties::Instance()->actions[ADD_TAB]->setShortcut(seq);
     connect(Properties::Instance()->actions[ADD_TAB], SIGNAL(triggered()), consoleTabulator, SLOT(addNewTab()));
     menu_File->addAction(Properties::Instance()->actions[ADD_TAB]);
 
     Properties::Instance()->actions[CLOSE_TAB] = new QAction(QIcon(":/icons/list-remove.png"), tr("Close Tab"), this);
-    seq = QKeySequence::fromString( settings.value(CLOSE_TAB, QKeySequence(QKeySequence::Close).toString()).toString() );
+    seq = QKeySequence::fromString( settings.value(CLOSE_TAB, CLOSE_TAB_SHORTCUT).toString() );
     Properties::Instance()->actions[CLOSE_TAB]->setShortcut(seq);
     connect(Properties::Instance()->actions[CLOSE_TAB], SIGNAL(triggered()), consoleTabulator, SLOT(removeCurrentTab()));
     menu_File->addAction(Properties::Instance()->actions[CLOSE_TAB]);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -283,7 +283,7 @@ TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * pa
 void TermWidget::propertiesChanged()
 {
     if (Properties::Instance()->highlightCurrentTerminal)
-        m_layout->setContentsMargins(3, 3, 3, 3);
+        m_layout->setContentsMargins(2, 2, 2, 2);
     else
         m_layout->setContentsMargins(0, 0, 0, 0);
 

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -168,12 +168,12 @@ void TermWidgetHolder::propertiesChanged()
 
 void TermWidgetHolder::splitHorizontal(TermWidget * term)
 {
-    split(term, Qt::Horizontal);
+    split(term, Qt::Vertical);
 }
 
 void TermWidgetHolder::splitVertical(TermWidget * term)
 {
-    split(term, Qt::Vertical);
+    split(term, Qt::Horizontal);
 }
 
 void TermWidgetHolder::splitCollapse(TermWidget * term)


### PR DESCRIPTION
- get rid of contraproductive Ctrl-W to close a tab. Replaced that with Ctrl-Shift-W. Use 
  nano in qterminal and try to search. You
  will see, what i mean ...
- it takes a horizontal ruler to tile a terminal vertically and
  vice versa
- make border of active terminal a litte bit thinner 3px -> 2px
