### PR TITLE
Check Ctrl manually on activateUrl signal

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -262,7 +262,9 @@ void TermWidgetImpl::enableCollapse(bool enable)
 }
 
 void TermWidgetImpl::activateUrl(const QUrl & url) {
-    QDesktopServices::openUrl(url);
+    if (QApplication::keyboardModifiers() & Qt::ControlModifier) {
+        QDesktopServices::openUrl(url);
+    }
 }
 
 TermWidget::TermWidget(const QString & wdir, const QString & shell, QWidget * parent)


### PR DESCRIPTION
Urls openes by click after some changes in qtermwidget https://github.com/qterminal/qtermwidget/pull/20. Added manually ctrl check as suggested in https://github.com/qterminal/qterminal/pull/69
