### PR TITLE
Left menu in properties dialog is able to be resized now.

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -27,7 +27,7 @@
    <item row="0" column="0">
     <widget class="QListWidget" name="listWidget">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -36,12 +36,6 @@
       <size>
        <width>100</width>
        <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>100</width>
-       <height>16777215</height>
       </size>
      </property>
      <item>


### PR DESCRIPTION
Left menu couldn't be resized, so user wasn't able to see full label. Now when whole window resizes, menu resizes too. (See screenshots).
![before](https://cloud.githubusercontent.com/assets/1764869/4739462/db1f622c-5a04-11e4-899f-35c2877fa2a9.png)
![after](https://cloud.githubusercontent.com/assets/1764869/4739461/db19fa94-5a04-11e4-8072-88e2d40ed830.png)
