### PR TITLE
Support secondary font

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>864</width>
-    <height>728</height>
+    <height>920</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -84,17 +84,17 @@
      </property>
      <widget class="QWidget" name="appearancePage">
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="8" column="0">
+       <item row="10" column="0">
         <widget class="QCheckBox" name="hideTabBarCheckBox">
          <property name="text">
           <string>Hide tab bar with only one tab</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="4" column="1">
         <widget class="QComboBox" name="colorSchemaCombo"/>
        </item>
-       <item row="2" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
           <string>Color scheme</string>
@@ -104,7 +104,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Scrollbar position</string>
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
+       <item row="19" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
@@ -124,20 +124,20 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="6" column="1">
         <widget class="QComboBox" name="scrollBarPos_comboBox"/>
        </item>
-       <item row="5" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="tabsPos_comboBox"/>
        </item>
-       <item row="9" column="0">
+       <item row="11" column="0">
         <widget class="QCheckBox" name="highlightCurrentCheckBox">
          <property name="text">
           <string>Show a border around the current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Terminal transparency</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="15" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Application transparency</string>
@@ -157,7 +157,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
+       <item row="19" column="1">
         <widget class="QComboBox" name="terminalPresetComboBox">
          <item>
           <property name="text">
@@ -181,7 +181,7 @@
          </item>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="15" column="1">
         <widget class="QSpinBox" name="appTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -258,10 +258,10 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="1">
+       <item row="5" column="1">
         <widget class="QComboBox" name="styleComboBox"/>
        </item>
-       <item row="5" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Tabs position</string>
@@ -271,10 +271,10 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="8" column="1">
         <widget class="QComboBox" name="keybCursorShape_comboBox"/>
        </item>
-       <item row="14" column="1">
+       <item row="16" column="1">
         <widget class="QSpinBox" name="termTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -290,7 +290,7 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Widget style</string>
@@ -300,7 +300,7 @@
          </property>
         </widget>
        </item>
-       <item row="18" column="0" colspan="2">
+       <item row="20" column="0" colspan="2">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -313,14 +313,14 @@
          </property>
         </spacer>
        </item>
-       <item row="7" column="0">
+       <item row="9" column="0">
         <widget class="QCheckBox" name="showMenuCheckBox">
          <property name="text">
           <string>Show the menu bar</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Keyboard cursor shape</string>
@@ -330,28 +330,28 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0" colspan="2">
+       <item row="12" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowTitleCheckBox">
          <property name="text">
           <string>Change window title based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="11" column="0" colspan="2">
+       <item row="13" column="0" colspan="2">
         <widget class="QCheckBox" name="changeWindowIconCheckBox">
          <property name="text">
           <string>Change window icon based on current terminal</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="18" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
           <string>Background image:</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="18" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -365,12 +365,83 @@
          </item>
         </layout>
        </item>
-       <item row="12" column="0">
+       <item row="14" column="0">
         <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
          <property name="text">
           <string>Show terminal size on resize</string>
          </property>
         </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QWidget" name="fontWidget2" native="true">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="secondaryFontLabel">
+            <property name="text">
+             <string>Secondary Font</string>
+            </property>
+            <property name="buddy">
+             <cstring>changeSecondaryFontButton</cstring>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="secondaryFontSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="secondaryFontSampleLabel">
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="changeSecondaryFontButton">
+            <property name="text">
+             <string>&amp;Change...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="text">
+          <string>Secondary Font title pattern</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QLineEdit" name="secondaryFontPatternTextEdit"/>
        </item>
       </layout>
      </widget>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>746</width>
-    <height>634</height>
+    <width>864</width>
+    <height>728</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,7 +114,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="label_9">
          <property name="text">
           <string>Start with preset:</string>
@@ -137,7 +137,7 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label">
          <property name="text">
           <string>Terminal transparency</string>
@@ -147,7 +147,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Application transparency</string>
@@ -157,7 +157,7 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QComboBox" name="terminalPresetComboBox">
          <item>
           <property name="text">
@@ -181,7 +181,7 @@
          </item>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QSpinBox" name="appTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -274,7 +274,7 @@
        <item row="6" column="1">
         <widget class="QComboBox" name="keybCursorShape_comboBox"/>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QSpinBox" name="termTransparencyBox">
          <property name="suffix">
           <string> %</string>
@@ -300,7 +300,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="0" colspan="2">
+       <item row="18" column="0" colspan="2">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -344,14 +344,14 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_13">
          <property name="text">
           <string>Background image:</string>
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
+       <item row="16" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -364,6 +364,13 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item row="12" column="0">
+        <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
+         <property name="text">
+          <string>Show terminal size on resize</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -76,6 +76,10 @@ void Properties::loadSettings()
     //Legacy font setting
     font = qvariant_cast<QFont>(m_settings->value("font", font));
 
+    secondaryFont = QFont(qvariant_cast<QString>(m_settings->value("secondaryFontFamily", defaultFont().family())),
+                          qvariant_cast<int>(m_settings->value("secondaryFontSize", defaultFont().pointSize())));
+    secondaryFontPattern = m_settings->value("secondaryFontPattern", "").toString();
+
     mainWindowSize = m_settings->value("MainWindow/size").toSize();
     mainWindowPosition = m_settings->value("MainWindow/pos").toPoint();
     mainWindowState = m_settings->value("MainWindow/state").toByteArray();
@@ -152,6 +156,10 @@ void Properties::saveSettings()
     m_settings->setValue("fontSize", font.pointSize());
     //Clobber legacy setting
     m_settings->remove("font");
+
+    m_settings->setValue("secondaryFontFamily", secondaryFont.family());
+    m_settings->setValue("secondaryFontSize", secondaryFont.pointSize());
+    m_settings->setValue("secondaryFontPattern", secondaryFontPattern);
 
     m_settings->beginGroup("Shortcuts");
     MainWindow *mainWindow = QTerminalApp::Instance()->getWindowList()[0];

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -69,6 +69,7 @@ void Properties::loadSettings()
     colorScheme = m_settings->value("colorScheme", "Linux").toString();
 
     highlightCurrentTerminal = m_settings->value("highlightCurrentTerminal", true).toBool();
+    showTerminalSizeHint = m_settings->value("showTerminalSizeHint", true).toBool();
 
     font = QFont(qvariant_cast<QString>(m_settings->value("fontFamily", defaultFont().family())),
                  qvariant_cast<int>(m_settings->value("fontSize", defaultFont().pointSize())));
@@ -146,6 +147,7 @@ void Properties::saveSettings()
     m_settings->setValue("guiStyle", guiStyle);
     m_settings->setValue("colorScheme", colorScheme);
     m_settings->setValue("highlightCurrentTerminal", highlightCurrentTerminal);
+    m_settings->setValue("showTerminalSizeHint", showTerminalSizeHint);
     m_settings->setValue("fontFamily", font.family());
     m_settings->setValue("fontSize", font.pointSize());
     //Clobber legacy setting

--- a/src/properties.h
+++ b/src/properties.h
@@ -50,6 +50,7 @@ class Properties
         QString colorScheme;
         QString guiStyle;
         bool highlightCurrentTerminal;
+        bool showTerminalSizeHint;
 
         bool historyLimited;
         unsigned historyLimitedTo;

--- a/src/properties.h
+++ b/src/properties.h
@@ -47,6 +47,10 @@ class Properties
         //ShortcutMap shortcuts;
         QString shell;
         QFont font;
+
+        QFont secondaryFont;
+        QString secondaryFontPattern;
+
         QString colorScheme;
         QString guiStyle;
         bool highlightCurrentTerminal;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -38,6 +38,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
             this, SLOT(apply()));
     connect(changeFontButton, SIGNAL(clicked()),
             this, SLOT(changeFontButton_clicked()));
+    connect(changeSecondaryFontButton, SIGNAL(clicked()),
+            this, SLOT(changeSecondaryFontButton_clicked()));
     connect(chooseBackgroundImageButton, &QPushButton::clicked,
             this, &PropertiesDialog::chooseBackgroundImageButton_clicked);
 
@@ -99,7 +101,10 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     if (ix != -1)
         styleComboBox->setCurrentIndex(ix);
 
-    setFontSample(Properties::Instance()->font);
+    setFontSample(Properties::Instance()->font, this->fontSampleLabel);
+    setFontSample(Properties::Instance()->secondaryFont, this->secondaryFontSampleLabel);
+
+    secondaryFontPatternTextEdit->setText(Properties::Instance()->secondaryFontPattern);
 
     appTransparencyBox->setValue(Properties::Instance()->appTransparency);
 
@@ -160,6 +165,10 @@ void PropertiesDialog::apply()
 {
     Properties::Instance()->colorScheme = colorSchemaCombo->currentText();
     Properties::Instance()->font = fontSampleLabel->font();//fontComboBox->currentFont();
+
+    Properties::Instance()->secondaryFont = secondaryFontSampleLabel->font();
+    Properties::Instance()->secondaryFontPattern = secondaryFontPatternTextEdit->text();
+
     Properties::Instance()->guiStyle = (styleComboBox->currentText() == tr("System Default")) ?
                                        QString() : styleComboBox->currentText();
 
@@ -217,11 +226,11 @@ void PropertiesDialog::apply()
     emit propertiesChanged();
 }
 
-void PropertiesDialog::setFontSample(const QFont & f)
+void PropertiesDialog::setFontSample(const QFont & f, QLabel * label)
 {
-    fontSampleLabel->setFont(f);
+    label->setFont(f);
     QString sample("%1 %2 pt");
-    fontSampleLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
+    label->setText(sample.arg(f.family()).arg(f.pointSize()));
 }
 
 void PropertiesDialog::changeFontButton_clicked()
@@ -231,7 +240,17 @@ void PropertiesDialog::changeFontButton_clicked()
         return;
     QFont f = dia.getFont();
     if (QFontInfo(f).fixedPitch())
-        setFontSample(f);
+        setFontSample(f, this->fontSampleLabel);
+}
+
+void PropertiesDialog::changeSecondaryFontButton_clicked()
+{
+    FontDialog dia(secondaryFontSampleLabel->font());
+    if (!dia.exec())
+        return;
+    QFont f = dia.getFont();
+    if (QFontInfo(f).fixedPitch())
+        setFontSample(f, this->secondaryFontSampleLabel);
 }
 
 void PropertiesDialog::chooseBackgroundImageButton_clicked()

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -107,6 +107,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     highlightCurrentCheckBox->setChecked(Properties::Instance()->highlightCurrentTerminal);
 
+    showTerminalSizeHintCheckBox->setChecked(Properties::Instance()->showTerminalSizeHint);
+
     askOnExitCheckBox->setChecked(Properties::Instance()->askOnExit);
 
     savePosOnExitCheckBox->setChecked(Properties::Instance()->savePosOnExit);
@@ -171,6 +173,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->termTransparency = termTransparencyBox->value();
     Properties::Instance()->highlightCurrentTerminal = highlightCurrentCheckBox->isChecked();
+    Properties::Instance()->showTerminalSizeHint = showTerminalSizeHintCheckBox->isChecked();
     Properties::Instance()->backgroundImage = backgroundImageLineEdit->text();
 
     Properties::Instance()->askOnExit = askOnExitCheckBox->isChecked();

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -35,7 +35,7 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         void propertiesChanged();
 
     private:
-        void setFontSample(const QFont & f);
+        void setFontSample(const QFont & f, QLabel * label);
         void openBookmarksFile(const QString &fname);
         void saveBookmarksFile(const QString &fname);
 
@@ -44,6 +44,7 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         void accept();
         
         void changeFontButton_clicked();
+        void changeSecondaryFontButton_clicked();
         void chooseBackgroundImageButton_clicked();
         void bookmarksButton_clicked();
 

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -85,6 +85,7 @@ void TermWidgetImpl::propertiesChanged()
     setColorScheme(Properties::Instance()->colorScheme);
     setTerminalFont(Properties::Instance()->font);
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
+    setTerminalSizeHint(Properties::Instance()->showTerminalSizeHint);
 
     if (Properties::Instance()->historyLimited)
     {

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -23,6 +23,7 @@
 #include <QMessageBox>
 #include <QAbstractButton>
 #include <QMouseEvent>
+#include <QRegularExpression>
 #include <assert.h>
 
 #ifdef HAVE_QDBUS
@@ -301,7 +302,29 @@ TermWidget::TermWidget(TerminalConfig &cfg, QWidget * parent)
     connect(m_term, SIGNAL(finished()), this, SIGNAL(finished()));
     connect(m_term, SIGNAL(termGetFocus()), this, SLOT(term_termGetFocus()));
     connect(m_term, SIGNAL(termLostFocus()), this, SLOT(term_termLostFocus()));
-    connect(m_term, &QTermWidget::titleChanged, this, [this] { emit termTitleChanged(m_term->title(), m_term->icon()); });
+    connect(m_term, SIGNAL(titleChanged()), this, SLOT(term_titleChanged()));
+}
+
+void TermWidget::term_titleChanged()
+{
+    QString title = m_term->title();
+
+    QRegularExpression re(Properties::Instance()->secondaryFontPattern);
+    QFont font = Properties::Instance()->font;
+    if (re.isValid() && re.match(title).hasMatch()) {
+        qDebug() << "Terminal title changed, pattern match, use secondary font";
+        font = Properties::Instance()->secondaryFont;
+    } else {
+        qDebug() << "Terminal title changed, use default font";
+    }
+
+    QFont current_font = m_term->getTerminalFont();
+    if (current_font.family() != font.family() || current_font.pointSize() != font.pointSize()) {
+        qDebug() << "Update terminal font to " << font << ", was " << current_font;
+        m_term->setTerminalFont(font);
+    }
+
+    emit termTitleChanged(title, m_term->icon());
 }
 
 void TermWidget::propertiesChanged()

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -96,6 +96,7 @@ class TermWidget : public QWidget, public DBusAddressable
         bool eventFilter(QObject * obj, QEvent * evt) override;
 
     private slots:
+        void term_titleChanged();
         void term_termGetFocus();
         void term_termLostFocus();
 };


### PR DESCRIPTION
Context:

I use vim in terminal to write codes. I like qterminal because it supports font ligatures so that codes in vim looks great. (I use [Fira Code](https://github.com/tonsky/FiraCode)). However there's a little problem: font ligatures are designed for codes, but not other terminal applications. E.g., the output of `htop` would looks strange (see below, `||` is displayed as ligature so not aligned):

![2017-11-01-00 46 15](https://user-images.githubusercontent.com/1308450/32236947-96551a90-be9e-11e7-88a4-b48c3ce0631b.png)

So basiclly I want to use different font for different terminal applications. Here I want to use "Fira Code" for vim, "Fira Mono" for everything else. This PR does exactly this.

![2017-11-01-00 51 47](https://user-images.githubusercontent.com/1308450/32237050-dfe17370-be9e-11e7-9012-f63a8a2beb86.png)

Every time terminal title changes, it's matched against the regex pattern from user settings. If matched, the "secondary font" would be used, otherwise the default font.

----

I understand that this feature is not something that everyone would use (too specific to myself), so there's little chance that this PR would be merged. But I really want to know your thoughts about this :P 

