### PR TITLE
Removes local compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ endif()
 
 add_definitions(
     -DSTR_VERSION=\"${STR_VERSION}\"
-    -DQT_NO_FOREACH
 )
 
 set(EXE_NAME qterminal)


### PR DESCRIPTION
QT_NO_FOREACH is already part of LXQtCompilerSettings CMake module.