### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,16 @@ add_executable(${EXE_NAME} ${GUI_TYPE}
     ${APPLE_BUNDLE_SOURCES}
     ${QTERM_QM}
 )
+
+target_compile_definitions(${EXE_NAME}
+    PRIVATE
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
+
 target_link_libraries(${EXE_NAME}
     Qt5::Gui
     qtermwidget5

--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -75,7 +75,7 @@ public:
         : AbstractBookmarkItem()
     {
         m_type = AbstractBookmarkItem::Root;
-        m_value = m_display = "root";
+        m_value = m_display = QStringLiteral("root");
     }
 };
 
@@ -132,8 +132,8 @@ public:
             }
             name = QStandardPaths::displayName(i);
 
-            path.replace(" ", "\\ ");
-            cmd = "cd " + path;
+            path.replace(QLatin1String(" "), QLatin1String("\\ "));
+            cmd = QLatin1String("cd ") + path;
 
             addChild(new BookmarkCommandItem(name, cmd, this));
         }
@@ -148,8 +148,8 @@ public:
             {
                 continue;
             }
-            path.replace(" ", "\\ ");
-            cmd = "cd " + path;
+            path.replace(QLatin1String(" "), QLatin1String("\\ "));
+            cmd = QLatin1String("cd ") + path;
             addChild(new BookmarkCommandItem(i, cmd, this));
         }
     }
@@ -188,9 +188,9 @@ public:
             {
                 AbstractBookmarkItem *parent = m_map.contains(xmlPos()) ? m_map[xmlPos()] : this;
                 QString tag = xml.name().toString();
-                if (tag == "group")
+                if (tag == QLatin1String("group"))
                 {
-                    QString name = xml.attributes().value("name").toString();
+                    QString name = xml.attributes().value(QLatin1String("name")).toString();
                     m_pos.append(name);
 
                     BookmarkGroupItem *i = new BookmarkGroupItem(name, parent);
@@ -198,10 +198,10 @@ public:
 
                     m_map[xmlPos()] = i;
                 }
-                else if (tag == "command")
+                else if (tag == QLatin1String("command"))
                 {
-                    QString name = xml.attributes().value("name").toString();
-                    QString cmd = xml.attributes().value("value").toString();
+                    QString name = xml.attributes().value(QLatin1String("name")).toString();
+                    QString cmd = xml.attributes().value(QLatin1String("value")).toString();
 
                     BookmarkCommandItem *i = new BookmarkCommandItem(name, cmd, parent);
                     parent->addChild(i);
@@ -211,7 +211,7 @@ public:
             case QXmlStreamReader::EndElement:
             {
                 QString tag = xml.name().toString();
-                if (tag == "group")
+                if (tag == QLatin1String("group"))
                 {
                     m_pos.removeLast();
                 }
@@ -233,7 +233,7 @@ public:
 
     QString xmlPos()
     {
-        return m_pos.join(".");
+        return m_pos.join(QLatin1Char('.'));
     }
 };
 
@@ -393,5 +393,5 @@ void BookmarksWidget::handleCommand(const QModelIndex& index)
     if (!item || item->type() != AbstractBookmarkItem::Command)
         return;
 
-    emit callCommand(item->value() + "\n"); // TODO/FIXME: decide how to handle EOL
+    emit callCommand(item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
 }

--- a/src/dbusaddressable.cpp
+++ b/src/dbusaddressable.cpp
@@ -20,6 +20,6 @@ DBusAddressable::DBusAddressable(QString prefix)
 {
     #ifdef HAVE_QDBUS
     QString uuidString = QUuid::createUuid().toString();
-    m_path = prefix + "/" + uuidString.replace(QRegExp("[\\{\\}\\-]"), "");
+    m_path = prefix + QLatin1Char('/') + uuidString.replace(QRegExp(QStringLiteral("[\\{\\}\\-]")), QString());
     #endif
 }

--- a/src/fontdialog.cpp
+++ b/src/fontdialog.cpp
@@ -50,7 +50,7 @@ QFont FontDialog::getFont()
 void FontDialog::setFontSample(const QFont &f)
 {
     previewLabel->setFont(f);
-    QString sample("%1 %2 pt");
+    QString sample(QLatin1String("%1 %2 pt"));
     previewLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
 }
 
@@ -58,6 +58,6 @@ void FontDialog::setFontSize()
 {
     const QFont &f = getFont();
     previewLabel->setFont(f);
-    QString sample("%1 %2 pt");
+    QString sample(QLatin1String("%1 %2 pt"));
     previewLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,23 +83,23 @@ void parse_args(int argc, char* argv[], QString& workdir, QString & shell_comman
                 print_usage_and_exit(0);
                 break;
             case 'w':
-                workdir = QString(optarg);
+                workdir = QString::fromLocal8Bit(optarg);
                 break;
             case 'e':
-                shell_command = QString(optarg);
+                shell_command = QString::fromLocal8Bit(optarg);
                 // #15 "Raw" -e params
                 // Passing "raw" params (like konsole -e mcedit /tmp/tmp.txt") is more preferable - then I can call QString("qterminal -e ") + cmd_line in other programs
                 while (optind < argc)
                 {
                     //printf("arg: %d - %s\n", optind, argv[optind]);
-                    shell_command += ' ' + QString(argv[optind++]);
+                    shell_command += QLatin1Char(' ') + QString::fromLocal8Bit(argv[optind++]);
                 }
                 break;
             case 'd':
                 dropMode = true;
                 break;
             case 'p':
-                Properties::Instance(QString(optarg));
+                Properties::Instance(QString::fromLocal8Bit(optarg));
                 break;
             case '?':
                 print_usage_and_exit(1);
@@ -114,9 +114,9 @@ void parse_args(int argc, char* argv[], QString& workdir, QString & shell_comman
 
 int main(int argc, char *argv[])
 {
-    QApplication::setApplicationName("qterminal");
-    QApplication::setApplicationVersion(STR_VERSION);
-    QApplication::setOrganizationDomain("qterminal.org");
+    QApplication::setApplicationName(QStringLiteral("qterminal"));
+    QApplication::setApplicationVersion(QStringLiteral(STR_VERSION));
+    QApplication::setOrganizationDomain(QStringLiteral("qterminal.org"));
 #if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     QApplication::setDesktopFileName(QLatin1String("qterminal.desktop"));
 #endif
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     const QSettings settings;
     const QFileInfo customStyle = QFileInfo(
         QFileInfo(settings.fileName()).canonicalPath() +
-        "/style.qss"
+        QStringLiteral("/style.qss")
     );
     if (customStyle.isFile() && customStyle.isReadable())
     {
@@ -158,14 +158,14 @@ int main(int argc, char *argv[])
     /* setup our custom icon theme if there is no system theme (OS X, Windows) */
     QCoreApplication::instance()->setAttribute(Qt::AA_UseHighDpiPixmaps); //Fix for High-DPI systems
     if (QIcon::themeName().isEmpty())
-        QIcon::setThemeName("QTerminal");
+        QIcon::setThemeName(QStringLiteral("QTerminal"));
 
     // translations
-    QString fname = QString("qterminal_%1.qm").arg(QLocale::system().name().left(5));
+    QString fname = QString::fromLatin1("qterminal_%1.qm").arg(QLocale::system().name().left(5));
     QTranslator translator;
 #ifdef TRANSLATIONS_DIR
     qDebug() << "TRANSLATIONS_DIR: Loading translation file" << fname << "from dir" << TRANSLATIONS_DIR;
-    qDebug() << "load success:" << translator.load(fname, TRANSLATIONS_DIR, "_");
+    qDebug() << "load success:" << translator.load(fname, QString::fromUtf8(TRANSLATIONS_DIR), QStringLiteral("+"));
 #endif
 #ifdef APPLE_BUNDLE
     qDebug() << "APPLE_BUNDLE: Loading translator file" << fname << "from dir" << QApplication::applicationDirPath()+"../translations";
@@ -269,7 +269,7 @@ void QTerminalApp::registerOnDbus()
         return;
     }
     new ProcessAdaptor(this);
-    QDBusConnection::sessionBus().registerObject("/", this);
+    QDBusConnection::sessionBus().registerObject(QStringLiteral("/"), this);
 }
 
 QList<QDBusObjectPath> QTerminalApp::getWindows()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -49,7 +49,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
                        QWidget * parent,
                        Qt::WindowFlags f)
     : QMainWindow(parent,f),
-      DBusAddressable("/windows"),
+      DBusAddressable(QStringLiteral("/windows")),
       tabPosition(NULL),
       scrollBarPosition(NULL),
       keyboardCursorShape(NULL),
@@ -77,7 +77,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setupUi(this);
 
     m_bookmarksDock = new QDockWidget(tr("Bookmarks"), this);
-    m_bookmarksDock->setObjectName("BookmarksDockWidget");
+    m_bookmarksDock->setObjectName(QStringLiteral("BookmarksDockWidget"));
     m_bookmarksDock->setAutoFillBackground(true);
     BookmarksWidget *bookmarksWidget = new BookmarksWidget(m_bookmarksDock);
     bookmarksWidget->setAutoFillBackground(true);
@@ -96,7 +96,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setContentsMargins(0, 0, 0, 0);
     if (m_dropMode) {
         this->enableDropMode();
-        setStyleSheet(QSS_DROP);
+        setStyleSheet(QStringLiteral(QSS_DROP));
     }
     else {
 	if (Properties::Instance()->saveSizeOnExit) {
@@ -176,27 +176,27 @@ void MainWindow::setup_Action(const char *name, QAction *action, const char *def
                               const char *slot, QMenu *menu, const QVariant &data)
 {
     QSettings settings;
-    settings.beginGroup("Shortcuts");
+    settings.beginGroup(QStringLiteral("Shortcuts"));
 
     QList<QKeySequence> shortcuts;
 
-    actions[name] = action;
-    const auto sequences = settings.value(name, defaultShortcut).toString().split('|');
+    actions[QLatin1String(name)] = action;
+    const auto sequences = settings.value(QLatin1String(name), QLatin1String(defaultShortcut)).toString().split(QLatin1Char('|'));
     for (const QString &sequenceString : sequences)
         shortcuts.append(QKeySequence::fromString(sequenceString));
-    actions[name]->setShortcuts(shortcuts);
+    actions[QLatin1String(name)]->setShortcuts(shortcuts);
 
     if (receiver)
     {
-        connect(actions[name], SIGNAL(triggered(bool)), receiver, slot);
-        addAction(actions[name]);
+        connect(actions[QLatin1String(name)], SIGNAL(triggered(bool)), receiver, slot);
+        addAction(actions[QLatin1String(name)]);
     }
 
     if (menu)
-        menu->addAction(actions[name]);
+        menu->addAction(actions[QLatin1String(name)]);
 
     if (!data.isNull())
-        actions[name]->setData(data);
+        actions[QLatin1String(name)]->setData(data);
 }
 
 void MainWindow::setup_ActionsMenu_Actions()
@@ -208,17 +208,17 @@ void MainWindow::setup_ActionsMenu_Actions()
 
     menu_Actions->clear();
 
-    setup_Action(CLEAR_TERMINAL, new QAction(QIcon::fromTheme("edit-clear"), tr("&Clear Active Terminal"), settingOwner),
+    setup_Action(CLEAR_TERMINAL, new QAction(QIcon::fromTheme(QStringLiteral("edit-clear")), tr("&Clear Active Terminal"), settingOwner),
                  CLEAR_TERMINAL_SHORTCUT, consoleTabulator, SLOT(clearActiveTerminal()), menu_Actions);
 
     menu_Actions->addSeparator();
 
     data.setValue(checkTabs);
 
-    setup_Action(TAB_NEXT, new QAction(QIcon::fromTheme("go-next"), tr("&Next Tab"), settingOwner),
+    setup_Action(TAB_NEXT, new QAction(QIcon::fromTheme(QStringLiteral("go-next")), tr("&Next Tab"), settingOwner),
                  TAB_NEXT_SHORTCUT, consoleTabulator, SLOT(switchToRight()), menu_Actions, data);
 
-    setup_Action(TAB_PREV, new QAction(QIcon::fromTheme("go-previous"), tr("&Previous Tab"), settingOwner),
+    setup_Action(TAB_PREV, new QAction(QIcon::fromTheme(QStringLiteral("go-previous")), tr("&Previous Tab"), settingOwner),
                  TAB_PREV_SHORTCUT, consoleTabulator, SLOT(switchToLeft()), menu_Actions, data);
 
     setup_Action(MOVE_LEFT, new QAction(tr("Move Tab &Left"), settingOwner),
@@ -240,43 +240,43 @@ void MainWindow::setup_ActionsMenu_Actions()
     setup_Action(SUB_COLLAPSE, new QAction(tr("&Collapse Subterminal"), settingOwner),
                  NULL, consoleTabulator, SLOT(splitCollapse()), menu_Actions, data);
 
-    setup_Action(SUB_TOP, new QAction(QIcon::fromTheme("go-up"), tr("&Top Subterminal"), settingOwner),
+    setup_Action(SUB_TOP, new QAction(QIcon::fromTheme(QStringLiteral("go-up")), tr("&Top Subterminal"), settingOwner),
                  SUB_TOP_SHORTCUT, consoleTabulator, SLOT(switchTopSubterminal()), menu_Actions, data);
 
-    setup_Action(SUB_BOTTOM, new QAction(QIcon::fromTheme("go-down"), tr("&Bottom Subterminal"), settingOwner),
+    setup_Action(SUB_BOTTOM, new QAction(QIcon::fromTheme(QStringLiteral("go-down")), tr("&Bottom Subterminal"), settingOwner),
                  SUB_BOTTOM_SHORTCUT, consoleTabulator, SLOT(switchBottomSubterminal()), menu_Actions, data);
 
-    setup_Action(SUB_LEFT, new QAction(QIcon::fromTheme("go-previous"), tr("L&eft Subterminal"), settingOwner),
+    setup_Action(SUB_LEFT, new QAction(QIcon::fromTheme(QStringLiteral("go-previous")), tr("L&eft Subterminal"), settingOwner),
                  SUB_LEFT_SHORTCUT, consoleTabulator, SLOT(switchLeftSubterminal()), menu_Actions, data);
 
-    setup_Action(SUB_RIGHT, new QAction(QIcon::fromTheme("go-next"), tr("R&ight Subterminal"), settingOwner),
+    setup_Action(SUB_RIGHT, new QAction(QIcon::fromTheme(QStringLiteral("go-next")), tr("R&ight Subterminal"), settingOwner),
                  SUB_RIGHT_SHORTCUT, consoleTabulator, SLOT(switchRightSubterminal()), menu_Actions, data);
 
 
     menu_Actions->addSeparator();
 
     // Copy and Paste are only added to the table for the sake of bindings at the moment; there is no Edit menu, only a context menu.
-    setup_Action(COPY_SELECTION, new QAction(QIcon::fromTheme("edit-copy"), tr("Copy &Selection"), settingOwner),
+    setup_Action(COPY_SELECTION, new QAction(QIcon::fromTheme(QStringLiteral("edit-copy")), tr("Copy &Selection"), settingOwner),
                  COPY_SELECTION_SHORTCUT, consoleTabulator, SLOT(copySelection()), menu_Edit);
 
-    setup_Action(PASTE_CLIPBOARD, new QAction(QIcon::fromTheme("edit-paste"), tr("Paste Clip&board"), settingOwner),
+    setup_Action(PASTE_CLIPBOARD, new QAction(QIcon::fromTheme(QStringLiteral("edit-paste")), tr("Paste Clip&board"), settingOwner),
                  PASTE_CLIPBOARD_SHORTCUT, consoleTabulator, SLOT(pasteClipboard()), menu_Edit);
 
-    setup_Action(PASTE_SELECTION, new QAction(QIcon::fromTheme("edit-paste"), tr("Paste S&election"), settingOwner),
+    setup_Action(PASTE_SELECTION, new QAction(QIcon::fromTheme(QStringLiteral("edit-paste")), tr("Paste S&election"), settingOwner),
                  PASTE_SELECTION_SHORTCUT, consoleTabulator, SLOT(pasteSelection()), menu_Edit);
 
-    setup_Action(ZOOM_IN, new QAction(QIcon::fromTheme("zoom-in"), tr("Zoom &in"), settingOwner),
+    setup_Action(ZOOM_IN, new QAction(QIcon::fromTheme(QStringLiteral("zoom-in")), tr("Zoom &in"), settingOwner),
                  ZOOM_IN_SHORTCUT, consoleTabulator, SLOT(zoomIn()), menu_Edit);
 
-    setup_Action(ZOOM_OUT, new QAction(QIcon::fromTheme("zoom-out"), tr("Zoom &out"), settingOwner),
+    setup_Action(ZOOM_OUT, new QAction(QIcon::fromTheme(QStringLiteral("zoom-out")), tr("Zoom &out"), settingOwner),
                  ZOOM_OUT_SHORTCUT, consoleTabulator, SLOT(zoomOut()), menu_Edit);
 
-    setup_Action(ZOOM_RESET, new QAction(QIcon::fromTheme("zoom-original"), tr("Zoom rese&t"), settingOwner),
+    setup_Action(ZOOM_RESET, new QAction(QIcon::fromTheme(QStringLiteral("zoom-original")), tr("Zoom rese&t"), settingOwner),
                  ZOOM_RESET_SHORTCUT, consoleTabulator, SLOT(zoomReset()), menu_Edit);
 
     menu_Actions->addSeparator();
 
-    setup_Action(FIND, new QAction(QIcon::fromTheme("edit-find"), tr("&Find..."), settingOwner),
+    setup_Action(FIND, new QAction(QIcon::fromTheme(QStringLiteral("edit-find")), tr("&Find..."), settingOwner),
                  FIND_SHORTCUT, this, SLOT(find()), menu_Actions);
 
 #if 0
@@ -310,7 +310,7 @@ void MainWindow::setup_ActionsMenu_Actions()
 void MainWindow::setup_FileMenu_Actions()
 {
     menu_File->clear();
-    setup_Action(ADD_TAB, new QAction(QIcon::fromTheme("list-add"), tr("&New Tab"), settingOwner),
+    setup_Action(ADD_TAB, new QAction(QIcon::fromTheme(QStringLiteral("list-add")), tr("&New Tab"), settingOwner),
                  ADD_TAB_SHORTCUT, this, SLOT(addNewTab()), menu_File);
 
     if (presetsMenu == NULL) {
@@ -327,10 +327,10 @@ void MainWindow::setup_FileMenu_Actions()
 
     menu_File->addMenu(presetsMenu);
 
-    setup_Action(CLOSE_TAB, new QAction(QIcon::fromTheme("list-remove"), tr("&Close Tab"), settingOwner),
+    setup_Action(CLOSE_TAB, new QAction(QIcon::fromTheme(QStringLiteral("list-remove")), tr("&Close Tab"), settingOwner),
                  CLOSE_TAB_SHORTCUT, consoleTabulator, SLOT(removeCurrentTab()), menu_File);
 
-    setup_Action(NEW_WINDOW, new QAction(QIcon::fromTheme("window-new"), tr("&New Window"), settingOwner),
+    setup_Action(NEW_WINDOW, new QAction(QIcon::fromTheme(QStringLiteral("window-new")), tr("&New Window"), settingOwner),
                  NEW_WINDOW_SHORTCUT, this, SLOT(newTerminalWindow()), menu_File);
 
     menu_File->addSeparator();
@@ -339,7 +339,7 @@ void MainWindow::setup_FileMenu_Actions()
 
     menu_File->addSeparator();
 
-    setup_Action(QUIT, new QAction(QIcon::fromTheme("application-exit"), tr("&Quit"), settingOwner), "", this, SLOT(close()), menu_File);
+    setup_Action(QUIT, new QAction(QIcon::fromTheme(QStringLiteral("application-exit")), tr("&Quit"), settingOwner), "", this, SLOT(close()), menu_File);
 }
 
 void MainWindow::setup_ViewMenu_Actions()
@@ -400,7 +400,7 @@ void MainWindow::setup_ViewMenu_Actions()
 
     if (tabPosMenu == NULL) {
         tabPosMenu = new QMenu(tr("&Tabs Layout"), menu_Window);
-        tabPosMenu->setObjectName("tabPosMenu");
+        tabPosMenu->setObjectName(QStringLiteral("tabPosMenu"));
 
         for(int i=0; i < tabPosition->actions().size(); ++i) {
             tabPosMenu->addAction(tabPosition->actions().at(i));
@@ -434,7 +434,7 @@ void MainWindow::setup_ViewMenu_Actions()
     }
     if (scrollPosMenu == NULL) {
         scrollPosMenu = new QMenu(tr("S&crollbar Layout"), menu_Window);
-        scrollPosMenu->setObjectName("scrollPosMenu");
+        scrollPosMenu->setObjectName(QStringLiteral("scrollPosMenu"));
 
         for(int i=0; i < scrollBarPosition->actions().size(); ++i) {
             scrollPosMenu->addAction(scrollBarPosition->actions().at(i));
@@ -466,7 +466,7 @@ void MainWindow::setup_ViewMenu_Actions()
 
     if (keyboardCursorShapeMenu == NULL) {
         keyboardCursorShapeMenu = new QMenu(tr("&Keyboard Cursor Shape"), menu_Window);
-        keyboardCursorShapeMenu->setObjectName("keyboardCursorShapeMenu");
+        keyboardCursorShapeMenu->setObjectName(QStringLiteral("keyboardCursorShapeMenu"));
 
         for(int i=0; i < keyboardCursorShape->actions().size(); ++i) {
             keyboardCursorShapeMenu->addAction(keyboardCursorShape->actions().at(i));
@@ -479,7 +479,7 @@ void MainWindow::setup_ViewMenu_Actions()
 void MainWindow::setupCustomDirs()
 {
     const QSettings settings;
-    const QString dir = QFileInfo(settings.fileName()).canonicalPath() + "/color-schemes/";
+    const QString dir = QFileInfo(settings.fileName()).canonicalPath() + QStringLiteral("/color-schemes/");
     TermWidgetImpl::addCustomColorSchemeDir(dir);
 }
 
@@ -490,7 +490,7 @@ void MainWindow::on_consoleTabulator_currentChanged(int)
 void MainWindow::toggleTabBar()
 {
     Properties::Instance()->tabBarless
-            = !actions[SHOW_TAB_BAR]->isChecked();
+            = !actions[QLatin1String(SHOW_TAB_BAR)]->isChecked();
     consoleTabulator->showHideTabBar();
 }
 
@@ -500,7 +500,7 @@ void MainWindow::toggleBorderless()
     show();
     setWindowState(Qt::WindowActive); /* don't loose focus on the window */
     Properties::Instance()->borderless
-            = actions[HIDE_WINDOW_BORDERS]->isChecked(); realign();
+            = actions[QLatin1String(HIDE_WINDOW_BORDERS)]->isChecked(); realign();
 }
 
 void MainWindow::toggleMenu()
@@ -555,7 +555,7 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
     // ask user for cancel only when there is at least one terminal active in this window
     QDialog * dia = new QDialog(this);
-    dia->setObjectName("exitDialog");
+    dia->setObjectName(QStringLiteral("exitDialog"));
     dia->setWindowTitle(tr("Exit QTerminal"));
 
     QCheckBox * dontAskCheck = new QCheckBox(tr("Do not ask again"), dia);
@@ -597,7 +597,7 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
 void MainWindow::actAbout_triggered()
 {
-    QMessageBox::about(this, QString("QTerminal ") + STR_VERSION, tr("A lightweight multiplatform terminal emulator"));
+    QMessageBox::about(this, QStringLiteral("QTerminal ") + QLatin1String(STR_VERSION), tr("A lightweight multiplatform terminal emulator"));
 }
 
 void MainWindow::actProperties_triggered()
@@ -621,7 +621,7 @@ void MainWindow::propertiesChanged()
 
     m_bookmarksDock->setVisible(Properties::Instance()->useBookmarks
                                 && Properties::Instance()->bookmarksVisible);
-    actions[TOGGLE_BOOKMARKS]->setVisible(Properties::Instance()->useBookmarks);
+    actions[QLatin1String(TOGGLE_BOOKMARKS)]->setVisible(Properties::Instance()->useBookmarks);
 
     if (Properties::Instance()->useBookmarks)
     {
@@ -677,9 +677,9 @@ void MainWindow::setKeepOpen(bool value)
         return;
 
     if (value)
-        m_dropLockButton->setIcon(QIcon::fromTheme("object-locked"));
+        m_dropLockButton->setIcon(QIcon::fromTheme(QStringLiteral("object-locked")));
     else
-        m_dropLockButton->setIcon(QIcon::fromTheme("object-unlocked"));
+        m_dropLockButton->setIcon(QIcon::fromTheme(QStringLiteral("object-unlocked")));
 
     m_dropLockButton->setChecked(value);
 }
@@ -750,7 +750,7 @@ void MainWindow::onCurrentTitleChanged(int index)
         icon = consoleTabulator->tabIcon(index);
     }
     setWindowTitle(title.isEmpty() || !Properties::Instance()->changeWindowTitle ? QStringLiteral("QTerminal") : title);
-    setWindowIcon(icon.isNull() || !Properties::Instance()->changeWindowIcon ? QIcon::fromTheme("utilities-terminal") : icon);
+    setWindowIcon(icon.isNull() || !Properties::Instance()->changeWindowIcon ? QIcon::fromTheme(QStringLiteral("utilities-terminal")) : icon);
 }
 
 bool MainWindow::hasMultipleTabs()

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -54,7 +54,7 @@ Properties::~Properties()
 QFont Properties::defaultFont()
 {
     QFont default_font = QApplication::font();
-    default_font.setFamily(DEFAULT_FONT);
+    default_font.setFamily(QLatin1String(DEFAULT_FONT));
     default_font.setPointSize(12);
     default_font.setStyleHint(QFont::TypeWriter);
     return default_font;
@@ -62,107 +62,107 @@ QFont Properties::defaultFont()
 
 void Properties::loadSettings()
 {
-    guiStyle = m_settings->value("guiStyle", QString()).toString();
+    guiStyle = m_settings->value(QLatin1String("guiStyle"), QString()).toString();
     if (!guiStyle.isNull())
         QApplication::setStyle(guiStyle);
 
-    colorScheme = m_settings->value("colorScheme", "Linux").toString();
+    colorScheme = m_settings->value(QLatin1String("colorScheme"), QLatin1String("Linux")).toString();
 
-    highlightCurrentTerminal = m_settings->value("highlightCurrentTerminal", true).toBool();
-    showTerminalSizeHint = m_settings->value("showTerminalSizeHint", true).toBool();
+    highlightCurrentTerminal = m_settings->value(QLatin1String("highlightCurrentTerminal"), true).toBool();
+    showTerminalSizeHint = m_settings->value(QLatin1String("showTerminalSizeHint"), true).toBool();
 
-    font = QFont(qvariant_cast<QString>(m_settings->value("fontFamily", defaultFont().family())),
-                 qvariant_cast<int>(m_settings->value("fontSize", defaultFont().pointSize())));
+    font = QFont(qvariant_cast<QString>(m_settings->value(QLatin1String("fontFamily"), defaultFont().family())),
+                 qvariant_cast<int>(m_settings->value(QLatin1String("fontSize"), defaultFont().pointSize())));
     //Legacy font setting
-    font = qvariant_cast<QFont>(m_settings->value("font", font));
+    font = qvariant_cast<QFont>(m_settings->value(QLatin1String("font"), font));
 
-    mainWindowSize = m_settings->value("MainWindow/size").toSize();
-    mainWindowPosition = m_settings->value("MainWindow/pos").toPoint();
-    mainWindowState = m_settings->value("MainWindow/state").toByteArray();
+    mainWindowSize = m_settings->value(QLatin1String("MainWindow/size")).toSize();
+    mainWindowPosition = m_settings->value(QLatin1String("MainWindow/pos")).toPoint();
+    mainWindowState = m_settings->value(QLatin1String("MainWindow/state")).toByteArray();
 
-    historyLimited = m_settings->value("HistoryLimited", true).toBool();
-    historyLimitedTo = m_settings->value("HistoryLimitedTo", 1000).toUInt();
+    historyLimited = m_settings->value(QLatin1String("HistoryLimited"), true).toBool();
+    historyLimitedTo = m_settings->value(QLatin1String("HistoryLimitedTo"), 1000).toUInt();
 
-    emulation = m_settings->value("emulation", "default").toString();
+    emulation = m_settings->value(QLatin1String("emulation"), QLatin1String("default")).toString();
 
     // sessions
-    int size = m_settings->beginReadArray("Sessions");
+    int size = m_settings->beginReadArray(QLatin1String("Sessions"));
     for (int i = 0; i < size; ++i)
     {
         m_settings->setArrayIndex(i);
-        QString name(m_settings->value("name").toString());
+        QString name(m_settings->value(QLatin1String("name")).toString());
         if (name.isEmpty())
             continue;
-        sessions[name] = m_settings->value("state").toByteArray();
+        sessions[name] = m_settings->value(QLatin1String("state")).toString();
     }
     m_settings->endArray();
 
-    appTransparency = m_settings->value("MainWindow/ApplicationTransparency", 0).toInt();
-    termTransparency = m_settings->value("TerminalTransparency", 0).toInt();
-    backgroundImage = m_settings->value("TerminalBackgroundImage", QString()).toString();
+    appTransparency = m_settings->value(QLatin1String("MainWindow/ApplicationTransparency"), 0).toInt();
+    termTransparency = m_settings->value(QLatin1String("TerminalTransparency"), 0).toInt();
+    backgroundImage = m_settings->value(QLatin1String("TerminalBackgroundImage"), QString()).toString();
 
     /* default to Right. see qtermwidget.h */
-    scrollBarPos = m_settings->value("ScrollbarPosition", 2).toInt();
+    scrollBarPos = m_settings->value(QLatin1String("ScrollbarPosition"), 2).toInt();
     /* default to North. I'd prefer South but North is standard (they say) */
-    tabsPos = m_settings->value("TabsPosition", 0).toInt();
+    tabsPos = m_settings->value(QLatin1String("TabsPosition"), 0).toInt();
     /* default to BlockCursor */
-    keyboardCursorShape = m_settings->value("KeyboardCursorShape", 0).toInt();
-    hideTabBarWithOneTab = m_settings->value("HideTabBarWithOneTab", false).toBool();
-    m_motionAfterPaste = m_settings->value("MotionAfterPaste", 0).toInt();
+    keyboardCursorShape = m_settings->value(QLatin1String("KeyboardCursorShape"), 0).toInt();
+    hideTabBarWithOneTab = m_settings->value(QLatin1String("HideTabBarWithOneTab"), false).toBool();
+    m_motionAfterPaste = m_settings->value(QLatin1String("MotionAfterPaste"), 0).toInt();
 
     /* tab width limit */
-    limitTabWidth = m_settings->value("LimitTabWidth", true).toBool();
-    limitTabWidthValue = m_settings->value("LimitTabWidthValue", 500).toInt();
-    showCloseTabButton = m_settings->value("ShowCloseTabButton", true).toBool();
+    limitTabWidth = m_settings->value(QLatin1String("LimitTabWidth"), true).toBool();
+    limitTabWidthValue = m_settings->value(QLatin1String("LimitTabWidthValue"), 500).toInt();
+    showCloseTabButton = m_settings->value(QLatin1String("ShowCloseTabButton"), true).toBool();
 
     /* toggles */
-    borderless = m_settings->value("Borderless", false).toBool();
-    tabBarless = m_settings->value("TabBarless", false).toBool();
-    menuVisible = m_settings->value("MenuVisible", true).toBool();
-    askOnExit = m_settings->value("AskOnExit", true).toBool();
-    saveSizeOnExit = m_settings->value("SaveSizeOnExit", true).toBool();
-    savePosOnExit = m_settings->value("SavePosOnExit", true).toBool();
-    useCWD = m_settings->value("UseCWD", false).toBool();
-    term = m_settings->value("Term", "xterm-256color").toString();
+    borderless = m_settings->value(QLatin1String("Borderless"), false).toBool();
+    tabBarless = m_settings->value(QLatin1String("TabBarless"), false).toBool();
+    menuVisible = m_settings->value(QLatin1String("MenuVisible"), true).toBool();
+    askOnExit = m_settings->value(QLatin1String("AskOnExit"), true).toBool();
+    saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
+    savePosOnExit = m_settings->value(QLatin1String("SavePosOnExit"), true).toBool();
+    useCWD = m_settings->value(QLatin1String("UseCWD"), false).toBool();
+    term = m_settings->value(QLatin1String("Term"), QLatin1String("xterm-256color")).toString();
 
     // bookmarks
-    useBookmarks = m_settings->value("UseBookmarks", false).toBool();
-    bookmarksVisible = m_settings->value("BookmarksVisible", true).toBool();
+    useBookmarks = m_settings->value(QLatin1String("UseBookmarks"), false).toBool();
+    bookmarksVisible = m_settings->value(QLatin1String("BookmarksVisible"), true).toBool();
     const QString s = QFileInfo(m_settings->fileName()).canonicalPath() + QString::fromLatin1("/qterminal_bookmarks.xml");
-    bookmarksFile = m_settings->value("BookmarksFile", s).toString();
+    bookmarksFile = m_settings->value(QLatin1String("BookmarksFile"), s).toString();
 
-    terminalsPreset = m_settings->value("TerminalsPreset", 0).toInt();
+    terminalsPreset = m_settings->value(QLatin1String("TerminalsPreset"), 0).toInt();
 
-    m_settings->beginGroup("DropMode");
-    dropShortCut = QKeySequence(m_settings->value("ShortCut", "F12").toString());
-    dropKeepOpen = m_settings->value("KeepOpen", false).toBool();
-    dropShowOnStart = m_settings->value("ShowOnStart", true).toBool();
-    dropWidht = m_settings->value("Width", 70).toInt();
-    dropHeight = m_settings->value("Height", 45).toInt();
+    m_settings->beginGroup(QLatin1String("DropMode"));
+    dropShortCut = QKeySequence(m_settings->value(QLatin1String("ShortCut"), QLatin1String("F12")).toString());
+    dropKeepOpen = m_settings->value(QLatin1String("KeepOpen"), false).toBool();
+    dropShowOnStart = m_settings->value(QLatin1String("ShowOnStart"), true).toBool();
+    dropWidht = m_settings->value(QLatin1String("Width"), 70).toInt();
+    dropHeight = m_settings->value(QLatin1String("Height"), 45).toInt();
     m_settings->endGroup();
 
-    changeWindowTitle = m_settings->value("ChangeWindowTitle", true).toBool();
-    changeWindowIcon = m_settings->value("ChangeWindowIcon", true).toBool();
-    enabledBidiSupport = m_settings->value("enabledBidiSupport", true).toBool();
+    changeWindowTitle = m_settings->value(QLatin1String("ChangeWindowTitle"), true).toBool();
+    changeWindowIcon = m_settings->value(QLatin1String("ChangeWindowIcon"), true).toBool();
+    enabledBidiSupport = m_settings->value(QLatin1String("enabledBidiSupport"), true).toBool();
 
-    confirmMultilinePaste = m_settings->value("ConfirmMultilinePaste", false).toBool();
-    trimPastedTrailingNewlines = m_settings->value("TrimPastedTrailingNewlines", false).toBool();
+    confirmMultilinePaste = m_settings->value(QLatin1String("ConfirmMultilinePaste"), false).toBool();
+    trimPastedTrailingNewlines = m_settings->value(QLatin1String("TrimPastedTrailingNewlines"), false).toBool();
 
-    windowMaximized = m_settings->value("LastWindowMaximized", false).toBool();
+    windowMaximized = m_settings->value(QLatin1String("LastWindowMaximized"), false).toBool();
 }
 
 void Properties::saveSettings()
 {
-    m_settings->setValue("guiStyle", guiStyle);
-    m_settings->setValue("colorScheme", colorScheme);
-    m_settings->setValue("highlightCurrentTerminal", highlightCurrentTerminal);
-    m_settings->setValue("showTerminalSizeHint", showTerminalSizeHint);
-    m_settings->setValue("fontFamily", font.family());
-    m_settings->setValue("fontSize", font.pointSize());
+    m_settings->setValue(QLatin1String("guiStyle"), guiStyle);
+    m_settings->setValue(QLatin1String("colorScheme"), colorScheme);
+    m_settings->setValue(QLatin1String("highlightCurrentTerminal"), highlightCurrentTerminal);
+    m_settings->setValue(QLatin1String("showTerminalSizeHint"), showTerminalSizeHint);
+    m_settings->setValue(QLatin1String("fontFamily"), font.family());
+    m_settings->setValue(QLatin1String("fontSize"), font.pointSize());
     //Clobber legacy setting
-    m_settings->remove("font");
+    m_settings->remove(QLatin1String("font"));
 
-    m_settings->beginGroup("Shortcuts");
+    m_settings->beginGroup(QLatin1String("Shortcuts"));
     MainWindow *mainWindow = QTerminalApp::Instance()->getWindowList()[0];
     assert(mainWindow != NULL);
 
@@ -174,78 +174,78 @@ void Properties::saveSettings()
         const auto shortcuts = it.value()->shortcuts();
         for (const QKeySequence &shortcut : shortcuts)
             sequenceStrings.append(shortcut.toString());
-        m_settings->setValue(it.key(), sequenceStrings.join('|'));
+        m_settings->setValue(it.key(), sequenceStrings.join(QLatin1Char('|')));
     }
     m_settings->endGroup();
 
-    m_settings->setValue("MainWindow/size", mainWindowSize);
-    m_settings->setValue("MainWindow/pos", mainWindowPosition);
-    m_settings->setValue("MainWindow/state", mainWindowState);
+    m_settings->setValue(QLatin1String("MainWindow/size"), mainWindowSize);
+    m_settings->setValue(QLatin1String("MainWindow/pos"), mainWindowPosition);
+    m_settings->setValue(QLatin1String("MainWindow/state"), mainWindowState);
 
-    m_settings->setValue("HistoryLimited", historyLimited);
-    m_settings->setValue("HistoryLimitedTo", historyLimitedTo);
+    m_settings->setValue(QLatin1String("HistoryLimited"), historyLimited);
+    m_settings->setValue(QLatin1String("HistoryLimitedTo"), historyLimitedTo);
 
-    m_settings->setValue("emulation", emulation);
+    m_settings->setValue(QLatin1String("emulation"), emulation);
 
     // sessions
-    m_settings->beginWriteArray("Sessions");
+    m_settings->beginWriteArray(QLatin1String("Sessions"));
     int i = 0;
     Sessions::iterator sit = sessions.begin();
     while (sit != sessions.end())
     {
         m_settings->setArrayIndex(i);
-        m_settings->setValue("name", sit.key());
-        m_settings->setValue("state", sit.value());
+        m_settings->setValue(QLatin1String("name"), sit.key());
+        m_settings->setValue(QLatin1String("state"), sit.value());
         ++sit;
         ++i;
     }
     m_settings->endArray();
 
-    m_settings->setValue("MainWindow/ApplicationTransparency", appTransparency);
-    m_settings->setValue("TerminalTransparency", termTransparency);
-    m_settings->setValue("TerminalBackgroundImage", backgroundImage);
-    m_settings->setValue("ScrollbarPosition", scrollBarPos);
-    m_settings->setValue("TabsPosition", tabsPos);
-    m_settings->setValue("KeyboardCursorShape", keyboardCursorShape);
-    m_settings->setValue("HideTabBarWithOneTab", hideTabBarWithOneTab);
-    m_settings->setValue("MotionAfterPaste", m_motionAfterPaste);
+    m_settings->setValue(QLatin1String("MainWindow/ApplicationTransparency"), appTransparency);
+    m_settings->setValue(QLatin1String("TerminalTransparency"), termTransparency);
+    m_settings->setValue(QLatin1String("TerminalBackgroundImage"), backgroundImage);
+    m_settings->setValue(QLatin1String("ScrollbarPosition"), scrollBarPos);
+    m_settings->setValue(QLatin1String("TabsPosition"), tabsPos);
+    m_settings->setValue(QLatin1String("KeyboardCursorShape"), keyboardCursorShape);
+    m_settings->setValue(QLatin1String("HideTabBarWithOneTab"), hideTabBarWithOneTab);
+    m_settings->setValue(QLatin1String("MotionAfterPaste"), m_motionAfterPaste);
 
-    m_settings->setValue("LimitTabWidth", limitTabWidth);
-    m_settings->setValue("LimitTabWidthValue", limitTabWidthValue);
-    m_settings->setValue("ShowCloseTabButton", showCloseTabButton);
+    m_settings->setValue(QLatin1String("LimitTabWidth"), limitTabWidth);
+    m_settings->setValue(QLatin1String("LimitTabWidthValue"), limitTabWidthValue);
+    m_settings->setValue(QLatin1String("ShowCloseTabButton"), showCloseTabButton);
 
-    m_settings->setValue("Borderless", borderless);
-    m_settings->setValue("TabBarless", tabBarless);
-    m_settings->setValue("MenuVisible", menuVisible);
-    m_settings->setValue("AskOnExit", askOnExit);
-    m_settings->setValue("SavePosOnExit", savePosOnExit);
-    m_settings->setValue("SaveSizeOnExit", saveSizeOnExit);
-    m_settings->setValue("UseCWD", useCWD);
-    m_settings->setValue("Term", term);
+    m_settings->setValue(QLatin1String("Borderless"), borderless);
+    m_settings->setValue(QLatin1String("TabBarless"), tabBarless);
+    m_settings->setValue(QLatin1String("MenuVisible"), menuVisible);
+    m_settings->setValue(QLatin1String("AskOnExit"), askOnExit);
+    m_settings->setValue(QLatin1String("SavePosOnExit"), savePosOnExit);
+    m_settings->setValue(QLatin1String("SaveSizeOnExit"), saveSizeOnExit);
+    m_settings->setValue(QLatin1String("UseCWD"), useCWD);
+    m_settings->setValue(QLatin1String("Term"), term);
 
     // bookmarks
-    m_settings->setValue("UseBookmarks", useBookmarks);
-    m_settings->setValue("BookmarksVisible", bookmarksVisible);
-    m_settings->setValue("BookmarksFile", bookmarksFile);
+    m_settings->setValue(QLatin1String("UseBookmarks"), useBookmarks);
+    m_settings->setValue(QLatin1String("BookmarksVisible"), bookmarksVisible);
+    m_settings->setValue(QLatin1String("BookmarksFile"), bookmarksFile);
 
-    m_settings->setValue("TerminalsPreset", terminalsPreset);
+    m_settings->setValue(QLatin1String("TerminalsPreset"), terminalsPreset);
 
-    m_settings->beginGroup("DropMode");
-    m_settings->setValue("ShortCut", dropShortCut.toString());
-    m_settings->setValue("KeepOpen", dropKeepOpen);
-    m_settings->setValue("ShowOnStart", dropShowOnStart);
-    m_settings->setValue("Width", dropWidht);
-    m_settings->setValue("Height", dropHeight);
+    m_settings->beginGroup(QLatin1String("DropMode"));
+    m_settings->setValue(QLatin1String("ShortCut"), dropShortCut.toString());
+    m_settings->setValue(QLatin1String("KeepOpen"), dropKeepOpen);
+    m_settings->setValue(QLatin1String("ShowOnStart"), dropShowOnStart);
+    m_settings->setValue(QLatin1String("Width"), dropWidht);
+    m_settings->setValue(QLatin1String("Height"), dropHeight);
     m_settings->endGroup();
 
-    m_settings->setValue("ChangeWindowTitle", changeWindowTitle);
-    m_settings->setValue("ChangeWindowIcon", changeWindowIcon);
-    m_settings->setValue("enabledBidiSupport", enabledBidiSupport);
+    m_settings->setValue(QLatin1String("ChangeWindowTitle"), changeWindowTitle);
+    m_settings->setValue(QLatin1String("ChangeWindowIcon"), changeWindowIcon);
+    m_settings->setValue(QLatin1String("enabledBidiSupport"), enabledBidiSupport);
 
-    m_settings->setValue("ConfirmMultilinePaste", confirmMultilinePaste);
-    m_settings->setValue("TrimPastedTrailingNewlines", trimPastedTrailingNewlines);
+    m_settings->setValue(QLatin1String("ConfirmMultilinePaste"), confirmMultilinePaste);
+    m_settings->setValue(QLatin1String("TrimPastedTrailingNewlines"), trimPastedTrailingNewlines);
 
-    m_settings->setValue("LastWindowMaximized", windowMaximized);
+    m_settings->setValue(QLatin1String("LastWindowMaximized"), windowMaximized);
 }
 
 void Properties::migrate_settings()
@@ -254,36 +254,36 @@ void Properties::migrate_settings()
     // If this method becomes unbearably huge we should look at the config-update
     // system used by kde and razor.
     QSettings settings;
-    QString lastVersion = settings.value("version", "0.0.0").toString();
-    QString currentVersion = STR_VERSION;
+    QString lastVersion = settings.value(QLatin1String("version"), QLatin1String("0.0.0")).toString();
+    QString currentVersion(QLatin1String(STR_VERSION));
     if (currentVersion < lastVersion)
     {
         qDebug() << "Warning: Configuration file was written by a newer version "
                  << "of QTerminal. Some settings might be incompatible";
     }
 
-    if (lastVersion < "0.4.0")
+    if (lastVersion < QLatin1String("0.4.0"))
     {
         // ===== Paste Selection -> Paste Clipboard =====
-        settings.beginGroup("Shortcuts");
-        if(!settings.contains(PASTE_CLIPBOARD))
+        settings.beginGroup(QLatin1String("Shortcuts"));
+        if(!settings.contains(QLatin1String(PASTE_CLIPBOARD)))
         {
-            QString value = settings.value("Paste Selection", PASTE_CLIPBOARD_SHORTCUT).toString();
-            settings.setValue(PASTE_CLIPBOARD, value);
+            QString value = settings.value(QLatin1String("Paste Selection"), QLatin1String(PASTE_CLIPBOARD_SHORTCUT)).toString();
+            settings.setValue(QLatin1String(PASTE_CLIPBOARD), value);
         }
-        settings.remove("Paste Selection");
+        settings.remove(QLatin1String("Paste Selection"));
         settings.endGroup();
     }
 
-    if (lastVersion <= "0.6.0")
+    if (lastVersion <= QLatin1String("0.6.0"))
     {
         // ===== AlwaysShowTabs -> HideTabBarWithOneTab =====
-        if(!settings.contains("HideTabBarWithOneTab"))
+        if(!settings.contains(QLatin1String("HideTabBarWithOneTab")))
         {
-            QString hideValue = settings.value("AlwaysShowTabs", false).toString();
-            settings.setValue("HideTabBarWithOneTab", hideValue);
+            QString hideValue = settings.value(QLatin1String("AlwaysShowTabs"), false).toString();
+            settings.setValue(QLatin1String("HideTabBarWithOneTab"), hideValue);
         }
-        settings.remove("AlwaysShowTabs");
+        settings.remove(QLatin1String("AlwaysShowTabs"));
 
         // ===== appOpacity -> ApplicationTransparency =====
         //
@@ -291,36 +291,36 @@ void Properties::migrate_settings()
         // restricted to [0,99] instead of [1,100]. We fix this here by
         // setting the opacity to 100 if it was 99 and to 1 if it was 0.
         //
-        if(!settings.contains("MainWindow/ApplicationTransparency"))
+        if(!settings.contains(QLatin1String("MainWindow/ApplicationTransparency")))
         {
-            int appOpacityValue = settings.value("MainWindow/appOpacity", 100).toInt();
+            int appOpacityValue = settings.value(QLatin1String("MainWindow/appOpacity"), 100).toInt();
             appOpacityValue = appOpacityValue == 99 ? 100 : appOpacityValue;
             appOpacityValue = appOpacityValue == 0 ? 1 : appOpacityValue;
-            settings.setValue("MainWindow/ApplicationTransparency", 100 - appOpacityValue);
+            settings.setValue(QLatin1String("MainWindow/ApplicationTransparency"), 100 - appOpacityValue);
         }
-        settings.remove("MainWindow/appOpacity");
+        settings.remove(QLatin1String("MainWindow/appOpacity"));
 
         // ===== termOpacity -> TerminalTransparency =====
-        if(!settings.contains("TerminalTransparency"))
+        if(!settings.contains(QLatin1String("TerminalTransparency")))
         {
-            int termOpacityValue = settings.value("termOpacity", 100).toInt();
+            int termOpacityValue = settings.value(QLatin1String("termOpacity"), 100).toInt();
             termOpacityValue = termOpacityValue == 99  ? 100 : termOpacityValue;
-            settings.setValue("TerminalTransparency", 100 - termOpacityValue);
+            settings.setValue(QLatin1String("TerminalTransparency"), 100 - termOpacityValue);
         }
-        settings.remove("termOpacity");
+        settings.remove(QLatin1String("termOpacity"));
 	// geometry -> size, pos
-	if (!settings.contains("MainWindow/size"))
+    if (!settings.contains(QLatin1String("MainWindow/size")))
 	{
 	    QWidget geom;
-	    geom.restoreGeometry(settings.value("MainWindow/geometry").toByteArray());
-            settings.setValue("MainWindow/size", geom.size());
-            settings.setValue("MainWindow/pos", geom.pos());
-            settings.setValue("MainWindow/isMaximized", geom.isMaximized());
-            settings.remove("MainWindow/geometry");
+        geom.restoreGeometry(settings.value(QLatin1String("MainWindow/geometry")).toByteArray());
+            settings.setValue(QLatin1String("MainWindow/size"), geom.size());
+            settings.setValue(QLatin1String("MainWindow/pos"), geom.pos());
+            settings.setValue(QLatin1String("MainWindow/isMaximized"), geom.isMaximized());
+            settings.remove(QLatin1String("MainWindow/geometry"));
 	}
     }
 
     if (currentVersion > lastVersion)
-        settings.setValue("version", currentVersion);
+        settings.setValue(QLatin1String("version"), currentVersion);
 }
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -265,7 +265,7 @@ void PropertiesDialog::apply()
 void PropertiesDialog::setFontSample(const QFont & f)
 {
     fontSampleLabel->setFont(f);
-    QString sample("%1 %2 pt");
+    QString sample = QString::fromLatin1("%1 %2 pt");
     fontSampleLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
 }
 
@@ -306,7 +306,7 @@ void PropertiesDialog::saveShortcuts()
         QString sequenceString = sequence.toString();
 
         QList<QKeySequence> shortcuts;
-        const auto sequences = item->text().split('|');
+        const auto sequences = item->text().split(QLatin1Char('|'));
         for (const QKeySequence& sequenceString : sequences)
             shortcuts.append(QKeySequence(sequenceString));
         keyAction->setShortcuts(shortcuts);
@@ -333,7 +333,7 @@ void PropertiesDialog::setupShortcuts()
             sequenceStrings.append(shortcut.toString());
 
         QTableWidgetItem *itemName = new QTableWidgetItem( tr(keyValue.toStdString().c_str()) );
-        QTableWidgetItem *itemShortcut = new QTableWidgetItem( sequenceStrings.join('|') );
+        QTableWidgetItem *itemShortcut = new QTableWidgetItem( sequenceStrings.join(QLatin1Char('|')) );
 
         itemName->setFlags( itemName->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsSelectable );
 
@@ -367,9 +367,9 @@ void PropertiesDialog::openBookmarksFile(const QString &fname)
     QFile f(fname);
     QString content;
     if (!f.open(QFile::ReadOnly))
-        content = "<qterminal>\n  <group name=\"group1\">\n    <command name=\"cmd1\" value=\"cd $HOME\"/>\n  </group>\n</qterminal>";
+        content = QString::fromLatin1("<qterminal>\n  <group name=\"group1\">\n    <command name=\"cmd1\" value=\"cd $HOME\"/>\n  </group>\n</qterminal>");
     else
-        content = f.readAll();
+        content = QString::fromUtf8(f.readAll());
 
     bookmarkPlainEdit->setPlainText(content);
     bookmarkPlainEdit->document()->setModified(false);

--- a/src/tabbar.cpp
+++ b/src/tabbar.cpp
@@ -29,7 +29,7 @@ TabBar::TabBar(QWidget *parent)
     QFont f = font();
     f.setBold(true);
     setFont(f);
-    setStyleSheet("QTabBar::tab:!selected { font-weight: normal; }");
+    setStyleSheet(QStringLiteral("QTabBar::tab:!selected { font-weight: normal; }"));
 }
 
 void TabBar::setLimitWidth(bool limitWidth)

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -226,10 +226,10 @@ void TabWidget::contextMenuEvent(QContextMenuEvent *event)
     QMenu menu(this);
     QMap< QString, QAction * > actions = findParent<MainWindow>(this)->leaseActions();
 
-    QAction *close = menu.addAction(QIcon::fromTheme("document-close"), tr("Close session"));
-    QAction *rename = menu.addAction(actions[RENAME_SESSION]->text());
-    QAction *changeColor = menu.addAction(QIcon::fromTheme("color-management"), tr("Change title color"));
-    rename->setShortcut(actions[RENAME_SESSION]->shortcut());
+    QAction *close = menu.addAction(QIcon::fromTheme(QStringLiteral("document-close")), tr("Close session"));
+    QAction *rename = menu.addAction(actions[QLatin1String(RENAME_SESSION)]->text());
+    QAction *changeColor = menu.addAction(QIcon::fromTheme(QStringLiteral("color-management")), tr("Change title color"));
+    rename->setShortcut(actions[QLatin1String(RENAME_SESSION)]->shortcut());
     rename->blockSignals(true);
 
     int tabIndex = tabBar()->tabAt(tabBar()->mapFrom(this,event->pos()));

--- a/src/terminalconfig.cpp
+++ b/src/terminalconfig.cpp
@@ -41,7 +41,7 @@ QString TerminalConfig::getShell()
     QByteArray envShell = qgetenv("SHELL");
     if (envShell.constData() != NULL)
     {
-        QString shellString = QString(envShell);
+        QString shellString = QString::fromLocal8Bit(envShell);
         if (!shellString.isEmpty())
             return shellString;
     }
@@ -73,9 +73,9 @@ void TerminalConfig::provideCurrentDirectory(const QString &val)
 TerminalConfig TerminalConfig::fromDbus(const QHash<QString,QVariant> &termArgsConst, TermWidget *toSplit)
 {
     QHash<QString,QVariant> termArgs(termArgsConst);
-    if (toSplit != NULL && !termArgs.contains(DBUS_ARG_WORKDIR))
+    if (toSplit != NULL && !termArgs.contains(QLatin1String(DBUS_ARG_WORKDIR)))
     {
-        termArgs[DBUS_ARG_WORKDIR] = QVariant(toSplit->impl()->workingDirectory());
+        termArgs[QLatin1String(DBUS_ARG_WORKDIR)] = QVariant(toSplit->impl()->workingDirectory());
     }
     return TerminalConfig::fromDbus(termArgs);
 }
@@ -89,14 +89,14 @@ static QString variantToString(QVariant variant, QString &defaultVal)
 
 TerminalConfig TerminalConfig::fromDbus(const QHash<QString,QVariant> &termArgs)
 {
-    QString wdir("");
+    QString wdir = QString();
     QString shell(Properties::Instance()->shell);
-    if (termArgs.contains(DBUS_ARG_WORKDIR))
+    if (termArgs.contains(QLatin1String(DBUS_ARG_WORKDIR)))
     {
-        wdir = variantToString(termArgs[DBUS_ARG_WORKDIR], wdir);
+        wdir = variantToString(termArgs[QLatin1String(DBUS_ARG_WORKDIR)], wdir);
     }
-    if (termArgs.contains(DBUS_ARG_SHELL)) {
-        shell = variantToString(termArgs[DBUS_ARG_SHELL], shell);
+    if (termArgs.contains(QLatin1String(DBUS_ARG_SHELL))) {
+        shell = variantToString(termArgs[QLatin1String(DBUS_ARG_SHELL)], shell);
     }
     return TerminalConfig(wdir, shell);
 }

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -45,7 +45,7 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     : QTermWidget(0, parent)
 {
     TermWidgetCount++;
-    QString name("TermWidget_%1");
+    QString name(QStringLiteral("TermWidget_%1"));
     setObjectName(name.arg(TermWidgetCount));
 
     setFlowControlEnabled(FLOW_CONTROL_ENABLED);
@@ -61,7 +61,7 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     if (!shell.isEmpty())
     {
         qDebug() << "Shell program:" << shell;
-        QStringList parts = shell.split(QRegExp("\\s+"), QString::SkipEmptyParts);
+        QStringList parts = shell.split(QRegExp(QStringLiteral("\\s+")), QString::SkipEmptyParts);
         qDebug() << parts;
         setShellProgram(parts.at(0));
         parts.removeAt(0);
@@ -148,21 +148,21 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
         menu.addSeparator();
     }
 
-    menu.addAction(actions[COPY_SELECTION]);
-    menu.addAction(actions[PASTE_CLIPBOARD]);
-    menu.addAction(actions[PASTE_SELECTION]);
-    menu.addAction(actions[ZOOM_IN]);
-    menu.addAction(actions[ZOOM_OUT]);
-    menu.addAction(actions[ZOOM_RESET]);
+    menu.addAction(actions[QStringLiteral(COPY_SELECTION)]);
+    menu.addAction(actions[QStringLiteral(PASTE_CLIPBOARD)]);
+    menu.addAction(actions[QStringLiteral(PASTE_SELECTION)]);
+    menu.addAction(actions[QStringLiteral(ZOOM_IN)]);
+    menu.addAction(actions[QStringLiteral(ZOOM_OUT)]);
+    menu.addAction(actions[QStringLiteral(ZOOM_RESET)]);
     menu.addSeparator();
-    menu.addAction(actions[CLEAR_TERMINAL]);
-    menu.addAction(actions[SPLIT_HORIZONTAL]);
-    menu.addAction(actions[SPLIT_VERTICAL]);
+    menu.addAction(actions[QStringLiteral(CLEAR_TERMINAL)]);
+    menu.addAction(actions[QStringLiteral(SPLIT_HORIZONTAL)]);
+    menu.addAction(actions[QStringLiteral(SPLIT_VERTICAL)]);
     // warning TODO/FIXME: disable the action when there is only one terminal
-    menu.addAction(actions[SUB_COLLAPSE]);
+    menu.addAction(actions[QStringLiteral(SUB_COLLAPSE)]);
     menu.addSeparator();
-    menu.addAction(actions[TOGGLE_MENU]);
-    menu.addAction(actions[PREFERENCES]);
+    menu.addAction(actions[QStringLiteral(TOGGLE_MENU)]);
+    menu.addAction(actions[QStringLiteral(PREFERENCES)]);
     menu.exec(mapToGlobal(pos));
 }
 
@@ -212,18 +212,18 @@ void TermWidgetImpl::paste(QClipboard::Mode mode)
     QString text = QApplication::clipboard()->text(mode);
     if ( ! text.isEmpty() )
     {
-        text.replace("\r\n", "\n");
-        text.replace('\n', '\r');
+        text.replace(QLatin1String("\r\n"), QLatin1String("\n"));
+        text.replace(QLatin1Char('\n'), QLatin1Char('\r'));
         QString trimmedTrailingNl(text);
-        trimmedTrailingNl.replace(QRegExp("\\r+$"), "");
-        bool isMultiline = trimmedTrailingNl.contains('\r');
+        trimmedTrailingNl.replace(QRegExp(QStringLiteral("\\r+$")), QString());
+        bool isMultiline = trimmedTrailingNl.contains(QLatin1Char('\r'));
         if (!isMultiline && Properties::Instance()->trimPastedTrailingNewlines)
         {
             text = trimmedTrailingNl;
         }
         if (Properties::Instance()->confirmMultilinePaste)
         {
-            if (text.contains('\r') && Properties::Instance()->confirmMultilinePaste)
+            if (text.contains(QLatin1Char('\r')) && Properties::Instance()->confirmMultilinePaste)
             {
                 QMessageBox confirmation(this);
                 confirmation.setWindowTitle(tr("Paste multiline text"));
@@ -270,7 +270,7 @@ bool TermWidget::eventFilter(QObject * /*obj*/, QEvent * ev)
 
 TermWidget::TermWidget(TerminalConfig &cfg, QWidget * parent)
     : QWidget(parent),
-      DBusAddressable("/terminals")
+      DBusAddressable(QStringLiteral("/terminals"))
 {
 
     #ifdef HAVE_QDBUS

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -38,7 +38,7 @@
 TermWidgetHolder::TermWidgetHolder(TerminalConfig &config, QWidget * parent)
     : QWidget(parent)
       #ifdef HAVE_QDBUS
-      , DBusAddressable("/tabs")
+      , DBusAddressable(QStringLiteral("/tabs"))
       #endif
 {
     #ifdef HAVE_QDBUS
@@ -117,14 +117,14 @@ void TermWidgetHolder::loadSession()
 void TermWidgetHolder::saveSession(const QString & name)
 {
     Session dump;
-    QString num("%1");
+    QString num(QLatin1String("%1"));
     const auto ws = findChildren<QSplitter*>();
     for(QSplitter *w : ws)
     {
-        dump += '|' + num.arg(w->orientation());
+        dump += QLatin1Char('|') + num.arg(w->orientation());
         const auto sizes = w->sizes();
         for (const int i : sizes)
-            dump += ',' + num.arg(i);
+            dump += QLatin1Char(',') + num.arg(i);
     }
     Properties::Instance()->sessions[name] = dump;
     qDebug() << "dump" << dump;


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.