### PR TITLE
Prevent TAB from changing focus in shortcut editor

### DIFF
--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -21,7 +21,6 @@
 #include <QDebug>
 #include <QStyleFactory>
 #include <QFileDialog>
-#include <QKeySequenceEdit>
 
 #include "propertiesdialog.h"
 #include "properties.h"
@@ -38,17 +37,23 @@ QWidget* Delegate::createEditor(QWidget *parent,
                                 const QStyleOptionViewItem& /*option*/,
                                 const QModelIndex& /*index*/) const
 {
-    return new QKeySequenceEdit (parent);
+    return new KeySequenceEdit(parent);
 }
 
 bool Delegate::eventFilter(QObject *object, QEvent *event)
 {
-    QWidget *editor = qobject_cast<QWidget*>(object);
+    KeySequenceEdit *editor = qobject_cast<KeySequenceEdit*>(object);
     if (editor && event->type() == QEvent::KeyPress) {
-        int k = static_cast<QKeyEvent *>(event)->key();
+        QKeyEvent *ke = static_cast<QKeyEvent *>(event);
+        int k = ke->key();
         if (k == Qt::Key_Return || k == Qt::Key_Enter) {
             emit QAbstractItemDelegate::commitData(editor);
             emit QAbstractItemDelegate::closeEditor(editor);
+            return true;
+        }
+        // treat Tab and Backtab like other keys
+        else if(k == Qt::Key_Tab || k ==  Qt::Key_Backtab) {
+            editor->pressKey(ke);
             return true;
         }
     }

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -20,7 +20,21 @@
 #define PROPERTIESDIALOG_H
 
 #include <QStyledItemDelegate>
+#include <QKeySequenceEdit>
 #include "ui_propertiesdialog.h"
+
+class KeySequenceEdit : public QKeySequenceEdit
+{
+    Q_OBJECT
+
+public:
+    KeySequenceEdit(QWidget *parent = nullptr) : QKeySequenceEdit(parent) {}
+
+    // to be used with Tab and Backtab
+    void pressKey(QKeyEvent *event) {
+        QKeySequenceEdit::keyPressEvent(event);
+    }
+};
 
 class Delegate : public QStyledItemDelegate
 {
@@ -56,7 +70,7 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
     private slots:
         void apply();
         void accept();
-        
+
         void changeFontButton_clicked();
         void chooseBackgroundImageButton_clicked();
         void bookmarksButton_clicked();


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/493

As a result, TAB can be included in shortcuts.