### PR TITLE
Bump minor version to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,9 @@ project(qterminal)
 include(GNUInstallDirs)
 
 # qterminal version
-set(QTERMINAL_VERSION "0.9.0")
+set(QTERMINAL_VERSION "0.14.0")
 set(LXQTBT_MINIMUM_VERSION "0.5.0")
-set(QTERMWIDGET_MINIMUM_VERSION "0.9.0")
+set(QTERMWIDGET_MINIMUM_VERSION "0.14.0")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 


### PR DESCRIPTION
Nice big bump to prevent conflicts with translations that are former built from
lxqt-l10n and have version 0.13.x