### PR TITLE
Don't translate xterm and xterm-256color

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -586,12 +586,12 @@
             </property>
             <item>
              <property name="text">
-              <string>xterm</string>
+              <string notr="true">xterm</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>xterm-256color</string>
+              <string notr="true">xterm-256color</string>
              </property>
             </item>
            </widget>


### PR DESCRIPTION
These are special terms and should not be translated like https://github.com/lxqt/qterminal/pull/519.

I think `*.ts` files should be updated and uploaded to WebLate? Not sure how to do that.