### PR TITLE
Revert "Adapt API changes in wip/issue358 branch of qtermwidget"

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -138,7 +138,7 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
     QMenu menu;
     QMap<QString, QAction*> actions = findParent<MainWindow>(this)->leaseActions();
 
-    QList<QAction*> extraActions = filterActions(pos, &menu);
+    QList<QAction*> extraActions = filterActions(pos);
     for (auto& action : extraActions)
     {
         menu.addAction(action);


### PR DESCRIPTION
This reverts commit cbdb9e2b107768a4e44b1890007eb44f73a2a1ba.

Reverted PR: #429

Adapt API changes after https://github.com/lxqt/qtermwidget/pull/242