### PR TITLE
Replace deprecated/removed Q_WS_MAC macro with Q_OS_MACOS

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -83,7 +83,7 @@
 #define SUB_LEFT_SHORTCUT	       "Alt+Left"
 #define SUB_RIGHT_SHORTCUT	       "Alt+Right"
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MACOS
 // It's tricky - Ctrl is "command" key on mac's keyboards
 #define COPY_SELECTION_SHORTCUT      "Ctrl+C"
 #define PASTE_CLIPBOARD_SHORTCUT      "Ctrl+V"


### PR DESCRIPTION
This was causing macOS to be misdetected under Qt 5.x.

Just like https://github.com/lxqt/qtermwidget/pull/254: Qt 5.x has removed the `Q_WS_MAC` macro, so you need to use `Q_OS_MACOS` instead.

This PR will make `config.h` correctly detect macOS and set up its keyboard shortcuts appropriately.

Prerequisite of https://github.com/lxqt/qterminal/issues/533.