### PR TITLE
Fix default font on macOS

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -69,7 +69,12 @@
 
 #define DEFAULT_WIDTH                  800
 #define DEFAULT_HEIGHT                 600
+#ifdef Q_OS_MACOS
+// Qt does not support fontconfig on macOS, so we need to use a "real" font name.
+#define DEFAULT_FONT                   "Menlo"
+#else
 #define DEFAULT_FONT                   "Monospace"
+#endif
 
 // ACTIONS
 #define CLEAR_TERMINAL_SHORTCUT        "Ctrl+Shift+X"


### PR DESCRIPTION
There is no "Monospace" font on macOS. Attempting to use it will cause you to fall back to a variable-width font instead, which is not appropriate for terminals.

This PR changes `config.h` to use "Monaco" on macOS.

Because fonts are saved in the QTerminal settings file and persist between runs, you may need to `rm -rf ~/.config/qterminal.org` to get this to take effect.

Follows up https://github.com/lxqt/qterminal/pull/562.