### PR TITLE
Fix missing PASTE_SELECTION_SHORTCUT on macOS

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,7 @@
 // It's tricky - Ctrl is "command" key on mac's keyboards
 #define COPY_SELECTION_SHORTCUT      "Ctrl+C"
 #define PASTE_CLIPBOARD_SHORTCUT      "Ctrl+V"
+#define PASTE_SELECTION_SHORTCUT      "Shift+Ins"
 #define FIND_SHORTCUT                "Ctrl+F"
 #define NEW_WINDOW_SHORTCUT          "Ctrl+N"
 #define ADD_TAB_SHORTCUT               "Ctrl+T"


### PR DESCRIPTION
One more thing: the macOS keyboard shortcut stanza is missing a definition for `PASTE_SELECTION_SHORTCUT`, which is used unconditionally by other code.

This PR fixes that by adding a `PASTE_SELECTION_SHORTCUT` definition inside the `#ifdef Q_OS_MACOS` section. This PR makes it Shift-Ins, same as on Linux (I don't know if that's actually Right with respect to Apple's HIG or existing macOS terminal emulator practice).

Without this, build fails on macOS:

```
/Users/janke/local/repos/qterminal/src/mainwindow.cpp:273:18: error: use of undeclared identifier 'PASTE_SELECTION_SHORTCUT'
                 PASTE_SELECTION_SHORTCUT, consoleTabulator, SLOT(pasteSelection()), menu_Edit);
                 ^
3 warnings and 1 error generated.
make[2]: *** [CMakeFiles/qterminal.dir/src/mainwindow.cpp.o] Error 1
make[1]: *** [CMakeFiles/qterminal.dir/all] Error 2
make: *** [all] Error 2
```

With this PR, build succeeds.

```
$ . ./my_cmake.sh                                                                                                                                     master
-- The C compiler identification is AppleClang 10.0.0.10001145
[...]
-- Generating done
-- Build files have been written to: /Users/janke/local/repos/qterminal-BUILD
$ make
[... too much scrollback! ...]
[  4%] Generating tabadaptor.cpp, tabadaptor.h
/usr/local/opt/qt/bin/qdbusxml2cpp -m -a tabadaptor -i termwidgetholder.h -l TermWidgetHolder /Users/janke/local/repos/qterminal/src/org.lxqt.QTerminal.Tab.xml
[  5%] Generating tabadaptor.moc
/usr/local/opt/qt/bin/moc @/Users/janke/local/repos/qterminal-BUILD/tabadaptor.moc_parameters
[...]
[100%] Built target qterminal
/usr/local/Cellar/cmake/3.13.4/bin/cmake -E cmake_progress_start /Users/janke/local/repos/qterminal-BUILD/CMakeFiles 0
$