### PR TITLE
Fix inconsistent-missing-override warnings.

### DIFF
--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -104,14 +104,14 @@ signals:
 
 protected:
     enum Direction{Left = 1, Right};
-    void contextMenuEvent(QContextMenuEvent * event);
+    void contextMenuEvent(QContextMenuEvent * event) override;
     void move(Direction);
     /*! Event filter for TabWidget's QTabBar. It's installed on tabBar()
         in the constructor.
         It's purpose is to handle doubleclicks on QTabBar for session
         renaming or new tab opening
      */
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 protected slots:
     void updateTabIndices();
     void onTermTitleChanged(QString title, QString icon);

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -92,7 +92,7 @@ class TermWidget : public QWidget, public DBusAddressable
     public slots:
 
     protected:
-        void paintEvent (QPaintEvent * event);
+        void paintEvent (QPaintEvent * event) override;
         bool eventFilter(QObject * obj, QEvent * evt) override;
 
     private slots:


### PR DESCRIPTION
Fixes #564 

This PR fixes the `warning: 'contextMenuEvent' overrides a member function but is not marked 'override'` warning messages in the build log output.

Example warning:

```
[  2%] Building CXX object CMakeFiles/qterminal.dir/src/tabwidget.cpp.o
/Applications/Xcode-10.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DHAVE_QDBUS -DQTERMINAL_VERSION=\"0.14.1\" -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_URL_CAST_FROM_STRING -DQT_USE_QSTRINGBUILDER -DQT_WIDGETS_LIB -DTRANSLATIONS_DIR=\"/tmp/test-lxqt/share/qterminal/translations\" -I/Users/janke/local/repos/qterminal -I/Users/janke/local/repos/qterminal/src -I/Users/janke/local/repos/qterminal-build -I/Users/janke/local/repos/qterminal/src/third-party -iframework /usr/local/opt/qt/lib -isystem /usr/local/opt/qt/lib/QtGui.framework/Headers -isystem /System/Library/Frameworks/OpenGL.framework/Headers -isystem /usr/local/opt/qt/lib/QtCore.framework/Headers -isystem /usr/local/opt/qt/./mkspecs/macx-clang -isystem /usr/local/include -isystem /usr/local/include/qtermwidget5 -isystem /usr/local/opt/qt/lib/QtWidgets.framework/Headers -isystem /usr/local/opt/qt/lib/QtDBus.framework/Headers  -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden   -fPIC -std=gnu++14 -o CMakeFiles/qterminal.dir/src/tabwidget.cpp.o -c /Users/janke/local/repos/qterminal/src/tabwidget.cpp
In file included from /Users/janke/local/repos/qterminal/src/tabwidget.cpp:25:
In file included from /Users/janke/local/repos/qterminal/src/mainwindow.h:22:
In file included from /Users/janke/local/repos/qterminal-build/ui_qterminal.h:20:
/Users/janke/local/repos/qterminal/src/tabwidget.h:107:10: warning: 'contextMenuEvent' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void contextMenuEvent(QContextMenuEvent * event);
         ^
/usr/local/opt/qt/lib/QtWidgets.framework/Headers/qwidget.h:630:18: note: overridden virtual function is here
    virtual void contextMenuEvent(QContextMenuEvent *event);
                 ^
In file included from /Users/janke/local/repos/qterminal/src/tabwidget.cpp:25:
In file included from /Users/janke/local/repos/qterminal/src/mainwindow.h:22:
In file included from /Users/janke/local/repos/qterminal-build/ui_qterminal.h:20:
/Users/janke/local/repos/qterminal/src/tabwidget.h:114:10: warning: 'eventFilter' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    bool eventFilter(QObject *obj, QEvent *event);
         ^
/usr/local/opt/qt/lib/QtCore.framework/Headers/qobject.h:128:18: note: overridden virtual function is here
    virtual bool eventFilter(QObject *watched, QEvent *event);
                 ^
In file included from /Users/janke/local/repos/qterminal/src/tabwidget.cpp:26:
In file included from /Users/janke/local/repos/qterminal/src/termwidgetholder.h:23:
/Users/janke/local/repos/qterminal/src/termwidget.h:95:14: warning: 'paintEvent' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        void paintEvent (QPaintEvent * event);
             ^
/usr/local/opt/qt/lib/QtWidgets.framework/Headers/qwidget.h:625:18: note: overridden virtual function is here
    virtual void paintEvent(QPaintEvent *event);
                 ^
3 warnings generated.
```
