### PR TITLE
Enable -Wall warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ project(qterminal)
 
 include(GNUInstallDirs)
 
+# Enable verbose warnings
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+
 # qterminal version
 set(QTERMINAL_VERSION "0.14.1")
 


### PR DESCRIPTION
What do you think about enabling verbose, conservative warnings with `-Wall -pedantic -Wextra`?

It would only add a couple warnings to the current build. And it might be helpful in proactively catching bugs.

New warnings exposed:

```
/Users/janke/local/repos/qterminal/src/third-party/qxtglobalshortcut_mac.cpp:237:23: warning:
      multi-character character constant [-Wfour-char-constants]
    keyID.signature = 'cute';
                      ^
1 warning generated.
[...]
In file included from /Users/janke/local/repos/qterminal-BUILD/src/moc_termwidget.cpp:9:
/Users/janke/local/repos/qterminal-BUILD/src/../../qterminal/src/termwidget.h:29:1: warning:
      'TermWidgetImpl' defined as a class here but previously declared as a struct [-Wmismatched-tags]
class TermWidgetImpl : public QTermWidget
^
/tmp/test-lxqt/include/qtermwidget5/qtermwidget.h:30:1: note: did you mean class here?
struct TermWidgetImpl;
^
[...]
In file included from /Users/janke/local/repos/qterminal-BUILD/src/moc_termwidgetholder.cpp:9:
In file included from /Users/janke/local/repos/qterminal-BUILD/src/../../qterminal/src/termwidgetholder.h:23:
/Users/janke/local/repos/qterminal/src/termwidget.h:29:1: warning: 'TermWidgetImpl' defined as a class
      here but previously declared as a struct [-Wmismatched-tags]
class TermWidgetImpl : public QTermWidget
^
/tmp/test-lxqt/include/qtermwidget5/qtermwidget.h:30:1: note: did you mean class here?
struct TermWidgetImpl;
^
```