### PR TITLE
Fix a couple typos in debug output

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -170,7 +170,7 @@ public:
         QFile f(fname);
         if (!f.open(QIODevice::ReadOnly))
         {
-            qDebug() << "Canot open file" << fname;
+            qDebug() << "Cannot open file" << fname;
             // TODO/FIXME: message box
             return;
         }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -262,7 +262,7 @@ void Properties::migrate_settings()
     if (currentVersion < lastVersion)
     {
         qDebug() << "Warning: Configuration file was written by a newer version "
-                 << "of QTerminal. Some settings might be incompatible";
+                 << "of QTerminal. Some settings might be incompatible.";
     }
 
     if (lastVersion < QLatin1String("0.4.0"))


### PR DESCRIPTION
Just a couple typo fixes in the debug output.

For the "Warning: Configuration file... incompatible" message, I think you need a period at the end because this line is multiple complete sentences, and a period was used after the first sentence.