### PR TITLE
Consider settings dialog frame on fitting it into screen

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -466,174 +466,211 @@
       </layout>
      </widget>
      <widget class="QWidget" name="behaviorPage">
-      <layout class="QGridLayout" name="gridLayout_5">
-       <item row="2" column="0">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="scrollArea1">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>57</height>
-          </size>
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
-        </spacer>
-       </item>
-       <item row="1" column="0">
-        <widget class="QGroupBox" name="groupBox_4">
-         <property name="title">
-          <string>Emulation</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_6">
-          <item row="0" column="0">
-           <widget class="QComboBox" name="emulationComboBox"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which behavior to emulate. Note that this does not have to match your operating system.&lt;/p&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600;&quot;&gt;default&lt;/span&gt; emulation is a fallback with a minimal featureset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="textFormat">
-             <enum>Qt::RichText</enum>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QGroupBox" name="groupBox_2">
-         <property name="title">
-          <string>Behavior</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Action after paste</string>
-            </property>
-            <property name="buddy">
-             <cstring>motionAfterPasting_comboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="3">
-           <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
-            <property name="text">
-             <string>Confirm multiline paste</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="3">
-           <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
-            <property name="text">
-             <string>Trim trailing newlines in pasted text</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QSpinBox" name="historyLimitedTo">
-            <property name="minimum">
-             <number>100</number>
-            </property>
-            <property name="maximum">
-             <number>1000000</number>
-            </property>
-            <property name="value">
-             <number>1000</number>
-            </property>
-           </widget>
-          </item>
-          <item row="10" column="1">
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>150</width>
-              <height>139</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="8" column="0" colspan="3">
-           <widget class="QCheckBox" name="useCwdCheckBox">
-            <property name="text">
-             <string>Open new terminals in current working directory</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0" colspan="3">
-           <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
-            <property name="text">
-             <string>Save Size when closing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="3">
-           <widget class="QCheckBox" name="savePosOnExitCheckBox">
-            <property name="text">
-             <string>Save Position when closing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="3">
-           <widget class="QCheckBox" name="askOnExitCheckBox">
-            <property name="text">
-             <string>Ask for confirmation when closing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QComboBox" name="motionAfterPasting_comboBox"/>
-          </item>
-          <item row="1" column="0" colspan="3">
-           <widget class="QRadioButton" name="historyUnlimited">
-            <property name="text">
-             <string>Unlimited history</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QRadioButton" name="historyLimited">
-            <property name="text">
-             <string>History size (in lines)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="0">
-           <widget class="QLabel" name="label_14">
-            <property name="text">
-             <string>Default $TERM</string>
-            </property>
-           </widget>
-          </item>
-          <item row="9" column="2">
-           <widget class="QComboBox" name="termComboBox">
-            <property name="editable">
-             <bool>true</bool>
-            </property>
-            <property name="currentIndex">
-             <number>1</number>
-            </property>
-            <item>
-             <property name="text">
-              <string notr="true">xterm</string>
+         <widget class="QWidget" name="scrollAreaWidgetContents1">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>508</width>
+            <height>658</height>
+           </rect>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="2" column="0">
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">xterm-256color</string>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>57</height>
+              </size>
              </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
+            </spacer>
+           </item>
+           <item row="1" column="0">
+            <widget class="QGroupBox" name="groupBox_4">
+             <property name="title">
+              <string>Emulation</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_6">
+              <item row="0" column="0">
+               <widget class="QComboBox" name="emulationComboBox"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which behavior to emulate. Note that this does not have to match your operating system.&lt;/p&gt;&lt;p&gt;The &lt;span style=&quot; font-weight:600;&quot;&gt;default&lt;/span&gt; emulation is a fallback with a minimal featureset.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QGroupBox" name="groupBox_2">
+             <property name="title">
+              <string>Behavior</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_2">
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Action after paste</string>
+                </property>
+                <property name="buddy">
+                 <cstring>motionAfterPasting_comboBox</cstring>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="3">
+               <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
+                <property name="text">
+                 <string>Confirm multiline paste</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="3">
+               <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
+                <property name="text">
+                 <string>Trim trailing newlines in pasted text</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QSpinBox" name="historyLimitedTo">
+                <property name="minimum">
+                 <number>100</number>
+                </property>
+                <property name="maximum">
+                 <number>1000000</number>
+                </property>
+                <property name="value">
+                 <number>1000</number>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="1">
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>150</width>
+                  <height>139</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="8" column="0" colspan="3">
+               <widget class="QCheckBox" name="useCwdCheckBox">
+                <property name="text">
+                 <string>Open new terminals in current working directory</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="3">
+               <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
+                <property name="text">
+                 <string>Save Size when closing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="3">
+               <widget class="QCheckBox" name="savePosOnExitCheckBox">
+                <property name="text">
+                 <string>Save Position when closing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0" colspan="3">
+               <widget class="QCheckBox" name="askOnExitCheckBox">
+                <property name="text">
+                 <string>Ask for confirmation when closing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QComboBox" name="motionAfterPasting_comboBox"/>
+              </item>
+              <item row="1" column="0" colspan="3">
+               <widget class="QRadioButton" name="historyUnlimited">
+                <property name="text">
+                 <string>Unlimited history</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="historyLimited">
+                <property name="text">
+                 <string>History size (in lines)</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="0">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Default $TERM</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="2">
+               <widget class="QComboBox" name="termComboBox">
+                <property name="editable">
+                 <bool>true</bool>
+                </property>
+                <property name="currentIndex">
+                 <number>1</number>
+                </property>
+                <item>
+                 <property name="text">
+                  <string notr="true">xterm</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">xterm-256color</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -190,17 +190,21 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     trimPastedTrailingNewlinesCheckBox->setChecked(Properties::Instance()->trimPastedTrailingNewlines);
     confirmMultilinePasteCheckBox->setChecked(Properties::Instance()->confirmMultilinePaste);
 
-    // show it compact inside available desktop geometry
+    // show it inside available desktop geometry
     QSize ag;
     if (parent != nullptr)
     {
         if (QWindow *win = parent->windowHandle())
         {
             if (QScreen *sc = win->screen())
-                ag = sc->availableVirtualGeometry().size();
+                ag = sc->availableVirtualGeometry().size()
+                     // also consider the parent frame thickness because the parent window
+                     // is fully formed and the frame thickness of the dialog is the same
+                     - (parent->window()->frameGeometry().size()
+                        - parent->window()->geometry().size());
         }
     }
-    resize(sizeHint().boundedTo(ag));
+    resize(size().boundedTo(ag));
 }
 
 


### PR DESCRIPTION
The frame thickness is taken from the terminal window, which is fully formed.

Also, by adding another scroll-bar to another page of the settings dialog, made it still more compact, so that now, it can fit into very small screens too.