### PR TITLE
fix: duplicated setHistorySize() call will overwrite the value set from Properties dialog

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -53,8 +53,6 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
 
     propertiesChanged();
 
-    setHistorySize(5000);
-
     setWorkingDirectory(cfg.getWorkingDirectory());
 
     QString shell = cfg.getShell();


### PR DESCRIPTION
`setHistorySize()` already called inside `propertiesChanged()` which are using the value we set from the Properties dialog:

https://github.com/lxqt/qterminal/blob/cd59a92276af9a6962cd374d377851f267bfe5c0/src/termwidget.cpp#L91-L99

So it seems call `setHistorySize()` after the `propertiesChanged()` will overwrite the value with the hardcoded `5000`.

https://github.com/lxqt/qterminal/blob/cd59a92276af9a6962cd374d377851f267bfe5c0/src/termwidget.cpp#L54-L56