### PR TITLE
WIP: Hide window decorations in Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,6 +174,8 @@ int main(int argc, char *argv[])
     app->installTranslator(&translator);
 
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
+    if (Properties::Instance()->borderless)
+        setenv("QT_WAYLAND_DISABLE_WINDOWDECORATION", "1", 0);
     app->newWindow(dropMode, initConfig);
 
     int ret = app->exec();


### PR DESCRIPTION
Hi!

I open this PR to discuss a proper solution to this problem : on Wayland, in a tiling window manager (I'm using [sway](https://github.com/swaywm/sway)), QTerminal will display window decorations around the terminal, no matter what the settings for borders are.

One solution I've found from this discussion qutebrowser/qutebrowser#2267 is to set the `QT_WAYLAND_DISABLE_WINDOWDECORATION` environment variable.

Launching the current release of QTerminal with this environment variable set does the trick, but I think a proper setting inside QTerminal itself would be the best solution, hence this Pull Request :)

From the qutebrowser discussion above, I understand that this environment variable should be set quite early for Qt to account for it. I've put it inside `main.cpp`, and that works fine, but I'm sure there is a better place for this. Being not familiar with this project's architecture, I came here to ask.