### PR TITLE
Allow to disable drawing line chars

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -112,109 +112,12 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>514</width>
-            <height>656</height>
+            <width>658</width>
+            <height>730</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="8" column="0">
-            <widget class="QCheckBox" name="hideTabBarCheckBox">
-             <property name="text">
-              <string>Hide tab bar with only one tab</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="colorSchemaCombo"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Color scheme</string>
-             </property>
-             <property name="buddy">
-              <cstring>colorSchemaCombo</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Scrollbar position</string>
-             </property>
-             <property name="buddy">
-              <cstring>scrollBarPos_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="19" column="0">
-            <widget class="QLabel" name="label_9">
-             <property name="text">
-              <string>Start with preset:</string>
-             </property>
-             <property name="buddy">
-              <cstring>terminalPresetComboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
-           </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="tabsPos_comboBox"/>
-           </item>
-           <item row="10" column="0">
-            <widget class="QCheckBox" name="highlightCurrentCheckBox">
-             <property name="text">
-              <string>Show a border around the current terminal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="17" column="0">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Terminal transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>termTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="16" column="0">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Application transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>appTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="19" column="1">
-            <widget class="QComboBox" name="terminalPresetComboBox">
-             <item>
-              <property name="text">
-               <string>None (single terminal)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals horizontally</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals vertically</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4 terminals</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="16" column="1">
+           <item row="17" column="1">
             <widget class="QSpinBox" name="appTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -291,36 +194,48 @@
              </layout>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="styleComboBox"/>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_8">
+           <item row="7" column="0">
+            <widget class="QCheckBox" name="showMenuCheckBox">
              <property name="text">
-              <string>Tabs position</string>
-             </property>
-             <property name="buddy">
-              <cstring>tabsPos_comboBox</cstring>
+              <string>Show the menu bar</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="1">
-            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="colorSchemaCombo"/>
            </item>
-           <item row="17" column="1">
-            <widget class="QSpinBox" name="termTransparencyBox">
-             <property name="suffix">
-              <string> %</string>
+           <item row="20" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>Start with preset:</string>
              </property>
-             <property name="minimum">
-              <number>0</number>
+             <property name="buddy">
+              <cstring>terminalPresetComboBox</cstring>
              </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
+            </widget>
+           </item>
+           <item row="20" column="1">
+            <widget class="QComboBox" name="terminalPresetComboBox">
+             <item>
+              <property name="text">
+               <string>None (single terminal)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals horizontally</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals vertically</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>4 terminals</string>
+              </property>
+             </item>
             </widget>
            </item>
            <item row="3" column="0">
@@ -333,65 +248,44 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="0" colspan="2">
-            <spacer name="verticalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>0</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item row="7" column="0">
-            <widget class="QCheckBox" name="showMenuCheckBox">
+           <item row="21" column="0">
+            <widget class="QLabel" name="label_15">
              <property name="text">
-              <string>Show the menu bar</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_12">
-             <property name="text">
-              <string>Cursor shape</string>
+              <string>Terminal margin</string>
              </property>
              <property name="buddy">
-              <cstring>keybCursorShape_comboBox</cstring>
+              <cstring>terminalMarginSpinBox</cstring>
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
-            <widget class="QCheckBox" name="changeWindowTitleCheckBox">
+           <item row="8" column="0">
+            <widget class="QCheckBox" name="hideTabBarCheckBox">
              <property name="text">
-              <string>Change window title based on current terminal</string>
+              <string>Hide tab bar with only one tab</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="0" colspan="2">
-            <widget class="QCheckBox" name="changeWindowIconCheckBox">
-             <property name="text">
-              <string>Change window icon based on current terminal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="15" column="0" colspan="2">
-            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
-             <property name="text">
-              <string>Enable bi-directional text support</string>
-             </property>
-            </widget>
-           </item>
-           <item row="18" column="0">
+           <item row="19" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="1">
+           <item row="4" column="1">
+            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Color scheme</string>
+             </property>
+             <property name="buddy">
+              <cstring>colorSchemaCombo</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="19" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -405,17 +299,109 @@
              </item>
             </layout>
            </item>
-           <item row="14" column="0">
-            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_12">
              <property name="text">
-              <string>Show terminal size on resize</string>
+              <string>Cursor shape</string>
+             </property>
+             <property name="buddy">
+              <cstring>keybCursorShape_comboBox</cstring>
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
-            <widget class="QCheckBox" name="fixedTabWidthCheckBox">
+           <item row="5" column="1">
+            <widget class="QComboBox" name="tabsPos_comboBox"/>
+           </item>
+           <item row="22" column="0" colspan="2">
+            <spacer name="verticalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item row="11" column="0">
+            <widget class="QCheckBox" name="closeTabButtonCheckBox">
              <property name="text">
-              <string>Fixed tab width:</string>
+              <string>Show close button on each tab</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>Scrollbar position</string>
+             </property>
+             <property name="buddy">
+              <cstring>scrollBarPos_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Terminal transparency</string>
+             </property>
+             <property name="buddy">
+              <cstring>termTransparencyBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
+           </item>
+           <item row="17" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Application transparency</string>
+             </property>
+             <property name="buddy">
+              <cstring>appTransparencyBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QCheckBox" name="highlightCurrentCheckBox">
+             <property name="text">
+              <string>Show a border around the current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="1">
+            <widget class="QSpinBox" name="terminalMarginSpinBox">
+             <property name="suffix">
+              <string>px</string>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="0" colspan="2">
+            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
+             <property name="text">
+              <string>Enable bi-directional text support</string>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="1">
+            <widget class="QSpinBox" name="termTransparencyBox">
+             <property name="suffix">
+              <string> %</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>0</number>
              </property>
             </widget>
            </item>
@@ -432,30 +418,51 @@
              </property>
             </widget>
            </item>
-           <item row="11" column="0">
-            <widget class="QCheckBox" name="closeTabButtonCheckBox">
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_8">
              <property name="text">
-              <string>Show close button on each tab</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="20" column="0">
-            <widget class="QLabel" name="label_15">
-             <property name="text">
-              <string>Terminal margin</string>
+              <string>Tabs position</string>
              </property>
              <property name="buddy">
-              <cstring>terminalMarginSpinBox</cstring>
+              <cstring>tabsPos_comboBox</cstring>
              </property>
             </widget>
            </item>
-           <item row="20" column="1">
-            <widget class="QSpinBox" name="terminalMarginSpinBox">
-             <property name="suffix">
-              <string>px</string>
+           <item row="12" column="0" colspan="2">
+            <widget class="QCheckBox" name="changeWindowTitleCheckBox">
+             <property name="text">
+              <string>Change window title based on current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QCheckBox" name="fixedTabWidthCheckBox">
+             <property name="text">
+              <string>Fixed tab width:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="styleComboBox"/>
+           </item>
+           <item row="13" column="0" colspan="2">
+            <widget class="QCheckBox" name="changeWindowIconCheckBox">
+             <property name="text">
+              <string>Change window icon based on current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="14" column="0">
+            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
+             <property name="text">
+              <string>Show terminal size on resize</string>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0">
+            <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
+             <property name="text">
+              <string>Use box drawing characters contained in the font</string>
              </property>
             </widget>
            </item>
@@ -495,8 +502,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>508</width>
-            <height>658</height>
+            <width>539</width>
+            <height>743</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -146,6 +146,7 @@ void Properties::loadSettings()
     changeWindowTitle = m_settings->value(QLatin1String("ChangeWindowTitle"), true).toBool();
     changeWindowIcon = m_settings->value(QLatin1String("ChangeWindowIcon"), true).toBool();
     enabledBidiSupport = m_settings->value(QLatin1String("enabledBidiSupport"), true).toBool();
+    useFontBoxDrawingChars = m_settings->value(QLatin1String("UseFontBoxDrawingChars"), false).toBool();
 
     confirmMultilinePaste = m_settings->value(QLatin1String("ConfirmMultilinePaste"), false).toBool();
     trimPastedTrailingNewlines = m_settings->value(QLatin1String("TrimPastedTrailingNewlines"), false).toBool();
@@ -244,6 +245,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("ChangeWindowTitle"), changeWindowTitle);
     m_settings->setValue(QLatin1String("ChangeWindowIcon"), changeWindowIcon);
     m_settings->setValue(QLatin1String("enabledBidiSupport"), enabledBidiSupport);
+    m_settings->setValue(QLatin1String("UseFontBoxDrawingChars"), useFontBoxDrawingChars);
 
     m_settings->setValue(QLatin1String("ConfirmMultilinePaste"), confirmMultilinePaste);
     m_settings->setValue(QLatin1String("TrimPastedTrailingNewlines"), trimPastedTrailingNewlines);

--- a/src/properties.h
+++ b/src/properties.h
@@ -109,7 +109,7 @@ class Properties
 
         bool windowMaximized;
 
-
+        bool useFontBoxDrawingChars;
     private:
 
         // Singleton handling

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -186,6 +186,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     changeWindowTitleCheckBox->setChecked(Properties::Instance()->changeWindowTitle);
     changeWindowIconCheckBox->setChecked(Properties::Instance()->changeWindowIcon);
     enabledBidiSupportCheckBox->setChecked(Properties::Instance()->enabledBidiSupport);
+    useFontBoxDrawingCharsCheckBox->setChecked(Properties::Instance()->useFontBoxDrawingChars);
 
     trimPastedTrailingNewlinesCheckBox->setChecked(Properties::Instance()->trimPastedTrailingNewlines);
     confirmMultilinePasteCheckBox->setChecked(Properties::Instance()->confirmMultilinePaste);
@@ -279,6 +280,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->changeWindowTitle = changeWindowTitleCheckBox->isChecked();
     Properties::Instance()->changeWindowIcon = changeWindowIconCheckBox->isChecked();
     Properties::Instance()->enabledBidiSupport = enabledBidiSupportCheckBox->isChecked();
+    Properties::Instance()->useFontBoxDrawingChars = useFontBoxDrawingCharsCheckBox->isChecked();
 
     Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
     Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -100,6 +100,7 @@ void TermWidgetImpl::propertiesChanged()
     setTerminalOpacity(1.0 - Properties::Instance()->termTransparency/100.0);
     setTerminalBackgroundImage(Properties::Instance()->backgroundImage);
     setBidiEnabled(Properties::Instance()->enabledBidiSupport);
+    setDrawLineChars(!Properties::Instance()->useFontBoxDrawingChars);
 
     /* be consequent with qtermwidget.h here */
     switch(Properties::Instance()->scrollBarPos) {


### PR DESCRIPTION
Depends on https://github.com/lxqt/qtermwidget/pull/275

To test it, run this command:
```
curl https://dl.chyen.cc/qtermwidget-alignment-test.txt
```

Preferences -> Appearance -> Draw line chars checked:
![圖片](https://user-images.githubusercontent.com/1937689/59109427-9b37a080-896f-11e9-90a3-f91ffb62326d.png)

Unchecked:
![圖片](https://user-images.githubusercontent.com/1937689/59109256-4c8a0680-896f-11e9-8024-0c66709a36a0.png)

Apparently this feature in qtermwidget is broken for at least Chinese characters, and Qt is drawing lines much better.

As the behavior before this patch is equivalent to that option checked, I keep the default checked.

This text file is copied by running `gpg --sign` with pinentry program set to `pinentry-curses` and `LC_ALL=zh_TW.UTF-8`. There are still two lines runs outside the box. I think it's an pinentry issue.

<del>The last word: I think the name "Draw line chars" is confusing unless one is familiar with how qtermwidget works. Need suggestions :)</del> Changed the option name, which is inspired by [a similar option in Konsole](https://github.com/KDE/konsole/blob/v19.04.2/src/EditProfileAppearancePage.ui#L198). The option name should be fine now :)