### PR TITLE
Make the initial terminal size consistent with qterminal.ui

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,10 +99,10 @@ MainWindow::MainWindow(TerminalConfig &cfg,
         setStyleSheet(QStringLiteral(QSS_DROP));
     }
     else {
-        if (Properties::Instance()->saveSizeOnExit) {
+        if (Properties::Instance()->saveSizeOnExit && Properties::Instance()->mainWindowSize.isValid()) {
             resize(Properties::Instance()->mainWindowSize);
         }
-        if (Properties::Instance()->savePosOnExit) {
+        if (Properties::Instance()->savePosOnExit && !Properties::Instance()->mainWindowPosition.isNull()) {
             move(Properties::Instance()->mainWindowPosition);
         }
         restoreState(Properties::Instance()->mainWindowState);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -313,16 +313,16 @@ void Properties::migrate_settings()
             settings.setValue(QLatin1String("TerminalTransparency"), 100 - termOpacityValue);
         }
         settings.remove(QLatin1String("termOpacity"));
-	// geometry -> size, pos
-    if (!settings.contains(QLatin1String("MainWindow/size")))
-	{
-	    QWidget geom;
-        geom.restoreGeometry(settings.value(QLatin1String("MainWindow/geometry")).toByteArray());
+        // geometry -> size, pos
+        if (!settings.contains(QLatin1String("MainWindow/size")) && settings.contains(QLatin1String("MainWindow/geometry")))
+        {
+            QWidget geom;
+            geom.restoreGeometry(settings.value(QLatin1String("MainWindow/geometry")).toByteArray());
             settings.setValue(QLatin1String("MainWindow/size"), geom.size());
             settings.setValue(QLatin1String("MainWindow/pos"), geom.pos());
             settings.setValue(QLatin1String("MainWindow/isMaximized"), geom.isMaximized());
             settings.remove(QLatin1String("MainWindow/geometry"));
-	}
+        }
     }
 
     if (currentVersion > lastVersion)


### PR DESCRIPTION
Ref: https://github.com/lxqt/qterminal/issues/492

When qterminal first runs, there is neither MainWindow/size nor MainWindow/geometry - there are no settings at all. Before this fix, geom will have an invalid geometry, and Qt fallbacks to 640x480 in such a case. That's why people see 640x480 qterminal at first run regardless of values in `qterminal.ui`.

The next step might be adjust values in `qterminal.ui` to have a bigger default qterminal window.