### PR TITLE
Made menubar accelerators optional

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -117,7 +117,7 @@
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="17" column="1">
+           <item row="18" column="1">
             <widget class="QSpinBox" name="appTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -194,7 +194,7 @@
              </layout>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="8" column="0">
             <widget class="QCheckBox" name="showMenuCheckBox">
              <property name="text">
               <string>Show the menu bar</string>
@@ -204,7 +204,7 @@
            <item row="2" column="1">
             <widget class="QComboBox" name="colorSchemaCombo"/>
            </item>
-           <item row="20" column="0">
+           <item row="21" column="0">
             <widget class="QLabel" name="label_9">
              <property name="text">
               <string>Start with preset:</string>
@@ -214,7 +214,7 @@
              </property>
             </widget>
            </item>
-           <item row="20" column="1">
+           <item row="21" column="1">
             <widget class="QComboBox" name="terminalPresetComboBox">
              <item>
               <property name="text">
@@ -248,7 +248,7 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
+           <item row="22" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Terminal margin</string>
@@ -258,14 +258,14 @@
              </property>
             </widget>
            </item>
-           <item row="8" column="0">
+           <item row="9" column="0">
             <widget class="QCheckBox" name="hideTabBarCheckBox">
              <property name="text">
               <string>Hide tab bar with only one tab</string>
              </property>
             </widget>
            </item>
-           <item row="19" column="0">
+           <item row="20" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
@@ -285,7 +285,7 @@
              </property>
             </widget>
            </item>
-           <item row="19" column="1">
+           <item row="20" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -312,7 +312,7 @@
            <item row="5" column="1">
             <widget class="QComboBox" name="tabsPos_comboBox"/>
            </item>
-           <item row="22" column="0" colspan="2">
+           <item row="23" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -325,7 +325,7 @@
              </property>
             </spacer>
            </item>
-           <item row="11" column="0">
+           <item row="12" column="0">
             <widget class="QCheckBox" name="closeTabButtonCheckBox">
              <property name="text">
               <string>Show close button on each tab</string>
@@ -345,7 +345,7 @@
              </property>
             </widget>
            </item>
-           <item row="18" column="0">
+           <item row="19" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Terminal transparency</string>
@@ -358,7 +358,7 @@
            <item row="6" column="1">
             <widget class="QComboBox" name="keybCursorShape_comboBox"/>
            </item>
-           <item row="17" column="0">
+           <item row="18" column="0">
             <widget class="QLabel" name="label_4">
              <property name="text">
               <string>Application transparency</string>
@@ -368,28 +368,28 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="0">
+           <item row="11" column="0">
             <widget class="QCheckBox" name="highlightCurrentCheckBox">
              <property name="text">
               <string>Show a border around the current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="1">
+           <item row="22" column="1">
             <widget class="QSpinBox" name="terminalMarginSpinBox">
              <property name="suffix">
               <string>px</string>
              </property>
             </widget>
            </item>
-           <item row="15" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
              <property name="text">
               <string>Enable bi-directional text support</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="1">
+           <item row="19" column="1">
             <widget class="QSpinBox" name="termTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -405,7 +405,7 @@
              </property>
             </widget>
            </item>
-           <item row="9" column="1">
+           <item row="10" column="1">
             <widget class="QSpinBox" name="fixedTabWidthSpinBox">
              <property name="enabled">
               <bool>false</bool>
@@ -428,14 +428,14 @@
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
+           <item row="13" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowTitleCheckBox">
              <property name="text">
               <string>Change window title based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
+           <item row="10" column="0">
             <widget class="QCheckBox" name="fixedTabWidthCheckBox">
              <property name="text">
               <string>Fixed tab width:</string>
@@ -445,24 +445,34 @@
            <item row="3" column="1">
             <widget class="QComboBox" name="styleComboBox"/>
            </item>
-           <item row="13" column="0" colspan="2">
+           <item row="14" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowIconCheckBox">
              <property name="text">
               <string>Change window icon based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="0">
+           <item row="15" column="0">
             <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
              <property name="text">
               <string>Show terminal size on resize</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0">
+           <item row="17" column="0">
             <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
              <property name="text">
               <string>Use box drawing characters contained in the font</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QCheckBox" name="menuAccelCheckBox">
+             <property name="toolTip">
+              <string>Accelerators are activated by Alt and can interfere with the terminal.</string>
+             </property>
+             <property name="text">
+              <string>No menu bar accelerator</string>
              </property>
             </widget>
            </item>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -113,6 +113,10 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     //consoleTabulator->setShellProgram(command);
 
+    const auto menuBarActions = m_menuBar->actions();
+    for (auto action : menuBarActions)
+        menubarOrigTexts << action->text();
+
     // apply props
     propertiesChanged();
 
@@ -637,6 +641,23 @@ void MainWindow::propertiesChanged()
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     consoleTabulator->propertiesChanged();
     setDropShortcut(Properties::Instance()->dropShortCut);
+
+
+    const auto menuBarActions = m_menuBar->actions();
+    if (Properties::Instance()->noMenubarAccel)
+    {
+        for (auto action : menuBarActions)
+            action->setText(action->text().remove(QLatin1Char('&')));
+    }
+    else if (menubarOrigTexts.size() == menuBarActions.size())
+    {
+        int i = 0;
+        for (auto action : menuBarActions)
+        {
+            action->setText(menubarOrigTexts.at(i));
+            ++i;
+        }
+    }
 
     m_menuBar->setVisible(Properties::Instance()->menuVisible);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -647,7 +647,12 @@ void MainWindow::propertiesChanged()
     if (Properties::Instance()->noMenubarAccel)
     {
         for (auto action : menuBarActions)
-            action->setText(action->text().remove(QLatin1Char('&')));
+        {
+            QString txt = action->text();
+            txt.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*"))); // Chinese and Japanese
+            txt.remove(QLatin1Char('&')); // other languages
+            action->setText(txt);
+        }
     }
     else if (menubarOrigTexts.size() == menuBarActions.size())
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -114,7 +114,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     //consoleTabulator->setShellProgram(command);
 
     const auto menuBarActions = m_menuBar->actions();
-    for (auto action : menuBarActions)
+    for (const auto& action : menuBarActions)
         menubarOrigTexts << action->text();
 
     // apply props
@@ -646,7 +646,7 @@ void MainWindow::propertiesChanged()
     const auto menuBarActions = m_menuBar->actions();
     if (Properties::Instance()->noMenubarAccel)
     {
-        for (auto action : menuBarActions)
+        for (auto& action : menuBarActions)
         {
             QString txt = action->text();
             txt.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*"))); // Chinese and Japanese
@@ -657,7 +657,7 @@ void MainWindow::propertiesChanged()
     else if (menubarOrigTexts.size() == menuBarActions.size())
     {
         int i = 0;
-        for (auto action : menuBarActions)
+        for (auto& action : menuBarActions)
         {
             action->setText(menubarOrigTexts.at(i));
             ++i;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -72,6 +72,8 @@ private:
                       const char *slot, QMenu *menu = nullptr, const QVariant &data = QVariant());
     QMap< QString, QAction * > actions;
 
+    QStringList menubarOrigTexts;
+
     void rebuildActions();
 
     void setup_FileMenu_Actions();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -121,6 +121,7 @@ void Properties::loadSettings()
     borderless = m_settings->value(QLatin1String("Borderless"), false).toBool();
     tabBarless = m_settings->value(QLatin1String("TabBarless"), false).toBool();
     menuVisible = m_settings->value(QLatin1String("MenuVisible"), true).toBool();
+    noMenubarAccel = m_settings->value(QLatin1String("NoMenubarAccel"), true).toBool();
     askOnExit = m_settings->value(QLatin1String("AskOnExit"), true).toBool();
     saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
     savePosOnExit = m_settings->value(QLatin1String("SavePosOnExit"), true).toBool();
@@ -220,6 +221,7 @@ void Properties::saveSettings()
 
     m_settings->setValue(QLatin1String("Borderless"), borderless);
     m_settings->setValue(QLatin1String("TabBarless"), tabBarless);
+    m_settings->setValue(QLatin1String("NoMenubarAccel"), noMenubarAccel);
     m_settings->setValue(QLatin1String("MenuVisible"), menuVisible);
     m_settings->setValue(QLatin1String("AskOnExit"), askOnExit);
     m_settings->setValue(QLatin1String("SavePosOnExit"), savePosOnExit);

--- a/src/properties.h
+++ b/src/properties.h
@@ -77,6 +77,7 @@ class Properties
 
         bool borderless;
         bool tabBarless;
+        bool noMenubarAccel;
         bool menuVisible;
 
         bool askOnExit;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -123,7 +123,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     hideTabBarCheckBox->setChecked(Properties::Instance()->hideTabBarWithOneTab);
 
-    // show main menu bar
+    // main menu bar
+    menuAccelCheckBox->setChecked(Properties::Instance()->noMenubarAccel);
     showMenuCheckBox->setChecked(Properties::Instance()->menuVisible);
 
     /* actions by motion after paste */
@@ -256,6 +257,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->keyboardCursorShape = keybCursorShape_comboBox->currentIndex();
     Properties::Instance()->showCloseTabButton = closeTabButtonCheckBox->isChecked();
     Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
+    Properties::Instance()->noMenubarAccel = menuAccelCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();
     Properties::Instance()->m_motionAfterPaste = motionAfterPasting_comboBox->currentIndex();
 

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -66,7 +66,7 @@ class TermWidget : public QWidget, public DBusAddressable
     public:
         TermWidget(TerminalConfig &cfg, QWidget * parent=nullptr);
 
-        void propertiesChanged(); 
+        void propertiesChanged();
         QStringList availableKeyBindings() { return m_term->availableKeyBindings(); }
 
         TermWidgetImpl * impl() { return m_term; }


### PR DESCRIPTION
Because `Alt+F` and some other shortcuts have meaning for a terminal emulator.

Fixes https://github.com/lxqt/qterminal/issues/485