### PR TITLE
Allow fixed custom size for QTerminal

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -707,7 +707,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="fixedSizeButton">
+                 <widget class="QPushButton" name="getCurrentSizeButton">
                   <property name="text">
                    <string>Get current size</string>
                   </property>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -588,7 +588,7 @@
                 </property>
                </widget>
               </item>
-              <item row="10" column="1">
+              <item row="11" column="1">
                <spacer name="verticalSpacer_4">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
@@ -601,7 +601,7 @@
                 </property>
                </spacer>
               </item>
-              <item row="8" column="0" colspan="3">
+              <item row="9" column="0" colspan="3">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
@@ -646,14 +646,14 @@
                 </property>
                </widget>
               </item>
-              <item row="9" column="0">
+              <item row="10" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="2">
+              <item row="10" column="2">
                <widget class="QComboBox" name="termComboBox">
                 <property name="editable">
                  <bool>true</bool>
@@ -672,6 +672,64 @@
                  </property>
                 </item>
                </widget>
+              </item>
+              <item row="8" column="0" colspan="3">
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <property name="spacing">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QLabel" name="fixedSizeLabel">
+                  <property name="text">
+                   <string>Start with this size:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="fixedWithSpinBox">
+                  <property name="suffix">
+                   <string> px</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="xLabel">
+                  <property name="text">
+                   <string notr="true">×</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QSpinBox" name="fixedHeightSpinBox">
+                  <property name="suffix">
+                   <string> px</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="fixedSizeButton">
+                  <property name="text">
+                   <string>Get current size</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::MinimumExpanding</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>5</width>
+                    <height>5</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -99,8 +99,12 @@ MainWindow::MainWindow(TerminalConfig &cfg,
         setStyleSheet(QStringLiteral(QSS_DROP));
     }
     else {
-        if (Properties::Instance()->saveSizeOnExit && Properties::Instance()->mainWindowSize.isValid()) {
-            resize(Properties::Instance()->mainWindowSize);
+        if (Properties::Instance()->saveSizeOnExit) {
+            if (Properties::Instance()->mainWindowSize.isValid())
+                resize(Properties::Instance()->mainWindowSize);
+        }
+        else if (Properties::Instance()->fixedWindowSize.isValid()) {
+            resize(Properties::Instance()->fixedWindowSize);
         }
         if (Properties::Instance()->savePosOnExit && !Properties::Instance()->mainWindowPosition.isNull()) {
             move(Properties::Instance()->mainWindowPosition);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -77,6 +77,7 @@ void Properties::loadSettings()
     font = qvariant_cast<QFont>(m_settings->value(QLatin1String("font"), font));
 
     mainWindowSize = m_settings->value(QLatin1String("MainWindow/size")).toSize();
+    fixedWindowSize = m_settings->value(QLatin1String("MainWindow/fixedSize"), QSize(600, 400)).toSize().expandedTo(QSize(300, 200));
     mainWindowPosition = m_settings->value(QLatin1String("MainWindow/pos")).toPoint();
     mainWindowState = m_settings->value(QLatin1String("MainWindow/state")).toByteArray();
 
@@ -182,6 +183,7 @@ void Properties::saveSettings()
     m_settings->endGroup();
 
     m_settings->setValue(QLatin1String("MainWindow/size"), mainWindowSize);
+    m_settings->setValue(QLatin1String("MainWindow/fixedSize"), fixedWindowSize);
     m_settings->setValue(QLatin1String("MainWindow/pos"), mainWindowPosition);
     m_settings->setValue(QLatin1String("MainWindow/state"), mainWindowState);
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -42,6 +42,7 @@ class Properties
         void migrate_settings();
 
         QSize mainWindowSize;
+        QSize fixedWindowSize;
         QPoint mainWindowPosition;
         QByteArray mainWindowState;
         //ShortcutMap shortcuts;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -80,9 +80,9 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
         xLabel->setEnabled(state == Qt::Unchecked);
         fixedWithSpinBox->setEnabled(state == Qt::Unchecked);
         fixedHeightSpinBox->setEnabled(state == Qt::Unchecked);
-        fixedSizeButton->setEnabled(state == Qt::Unchecked);
+        getCurrentSizeButton->setEnabled(state == Qt::Unchecked);
     });
-    connect(fixedSizeButton, &QAbstractButton::clicked, [this, parent] {
+    connect(getCurrentSizeButton, &QAbstractButton::clicked, [this, parent] {
         if (parent != nullptr)
         {
             QSize pSize = parent->window()->geometry().size();


### PR DESCRIPTION
Closes https://github.com/lxqt/qterminal/issues/492

If the window size is not remembered on exiting, the custom width and height could be set in Preferences. Then, QTerminal will always have that size on starting. Of course, the maximized state is also saved/restored, as before.

Although the size is in pixels (not in characters), a button is added for getting the current size, so that the user could first resize QTerminal and then open Preferences and get the size. In this way, (1) lots of complex calculations are prevented, and (2) differences in tastes are respected.