### PR TITLE
No more incorrectly setting icon via OSC 1

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -179,7 +179,13 @@ void TabWidget::onTermTitleChanged(QString title, QString icon)
     {
         const int index = console->property(TAB_INDEX_PROPERTY).toInt();
 
-        setTabIcon(index, QIcon::fromTheme(icon));
+        /* In xterm, the icon string maps to the X11 WM_ICON_NAME property.
+         * Doing nothing here for several reasons:
+         * 1. Few X11 window managers use that
+         * 2. X11-only code is involved
+         */
+        Q_UNUSED(icon);
+
         setTabText(index, title);
         if (currentIndex() == index)
             emit currentTitleChanged(index);


### PR DESCRIPTION
Closes: https://github.com/lxqt/qtermwidget/issues/286

I leave other icon-handling code there as in the future I may add another escape sequence to change tab icons.