### PR TITLE
Fix warning.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,7 +119,9 @@ int main(int argc, char *argv[])
         // On macOS, if qterminal.app is spawned by launchd (e.g., from Finder
         // or use `open qterminal.app`, $PWD is set to /. Workaround that by
         // go to $HOME first.
-        chdir(QDir::homePath().toLatin1().data());
+        if (chdir(QDir::homePath().toLatin1().data())) {
+            qDebug() << "Failed to chdir to $HOME" << QDir::homePath() << strerror(errno);
+        }
 
         // also initializes $LANG
         QString systemLocaleName(QLocale().name());


### PR DESCRIPTION
I got this one:

../src/main.cpp: In function ‘int main(int, char**)’:
../src/main.cpp:122:14: warning: ignoring return value of ‘int chdir(const char*)’, declared with attribute warn_unused_result [-Wunused-result]
         chdir(QDir::homePath().toLatin1().data());
         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

From gcc (Ubuntu 8.3.0-6ubuntu1) 8.3.0