### PR TITLE
config: add a tooltip regard box-drawing chars

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -455,6 +455,9 @@
            </item>
            <item row="17" column="0" colspan="2">
             <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
+             <property name="toolTip">
+              <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
+             </property>
              <property name="text">
               <string>Use box drawing characters contained in the font</string>
              </property>


### PR DESCRIPTION
It's a bit unclear what the option actually does, so I suggest adding the tooltip.
The tooltip is based on the documentation from qtermwidget: https://github.com/lxqt/qtermwidget/blob/64fef7ab3cad490fb51b57f2b13fc2bed8ec921d/lib/TerminalDisplay.h#L354

Feel free to alter the text If you think so.