### PR TITLE
Update disabled actions after a tab dies.

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -295,6 +295,8 @@ void TabWidget::removeFinished()
 //        if (count() == 0)
 //            emit closeTabNotification();
     }
+
+    findParent<MainWindow>(this)->updateDisabledActions();
 }
 
 void TabWidget::removeTab(int index)


### PR DESCRIPTION
Actions do not get properly enabled/disabled after closing a tab.

To reproduce:

Start qterminal
split tab in two (vertical or horizonal)
create another tab
close this tab (Ctrl-D)
Notice how the actions for switching between the subterminals on the first tab are disabled