### PR TITLE
Make close-on-middle-click optional

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -111,7 +111,7 @@
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="19" column="1">
+           <item row="20" column="1">
             <widget class="QSpinBox" name="appTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -198,7 +198,7 @@
            <item row="2" column="1">
             <widget class="QComboBox" name="colorSchemaCombo"/>
            </item>
-           <item row="22" column="0">
+           <item row="23" column="0">
             <widget class="QLabel" name="label_9">
              <property name="text">
               <string>Start with preset:</string>
@@ -208,7 +208,7 @@
              </property>
             </widget>
            </item>
-           <item row="22" column="1">
+           <item row="23" column="1">
             <widget class="QComboBox" name="terminalPresetComboBox">
              <item>
               <property name="text">
@@ -242,7 +242,7 @@
              </property>
             </widget>
            </item>
-           <item row="23" column="0">
+           <item row="24" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Terminal margin</string>
@@ -259,7 +259,7 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
+           <item row="22" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
@@ -279,7 +279,7 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="1">
+           <item row="22" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -306,7 +306,7 @@
            <item row="5" column="1">
             <widget class="QComboBox" name="tabsPos_comboBox"/>
            </item>
-           <item row="24" column="0" colspan="2">
+           <item row="25" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -339,7 +339,7 @@
              </property>
             </widget>
            </item>
-           <item row="20" column="0">
+           <item row="21" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Terminal transparency</string>
@@ -352,7 +352,7 @@
            <item row="6" column="1">
             <widget class="QComboBox" name="keybCursorShape_comboBox"/>
            </item>
-           <item row="19" column="0">
+           <item row="20" column="0">
             <widget class="QLabel" name="label_4">
              <property name="text">
               <string>Application transparency</string>
@@ -369,21 +369,21 @@
              </property>
             </widget>
            </item>
-           <item row="23" column="1">
+           <item row="24" column="1">
             <widget class="QSpinBox" name="terminalMarginSpinBox">
              <property name="suffix">
               <string>px</string>
              </property>
             </widget>
            </item>
-           <item row="17" column="0" colspan="2">
+           <item row="18" column="0" colspan="2">
             <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
              <property name="text">
               <string>Enable bi-directional text support</string>
              </property>
             </widget>
            </item>
-           <item row="20" column="1">
+           <item row="21" column="1">
             <widget class="QSpinBox" name="termTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -422,7 +422,7 @@
              </property>
             </widget>
            </item>
-           <item row="14" column="0" colspan="2">
+           <item row="15" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowTitleCheckBox">
              <property name="text">
               <string>Change window title based on current terminal</string>
@@ -439,21 +439,21 @@
            <item row="3" column="1">
             <widget class="QComboBox" name="styleComboBox"/>
            </item>
-           <item row="15" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowIconCheckBox">
              <property name="text">
               <string>Change window icon based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0" colspan="2">
+           <item row="17" column="0" colspan="2">
             <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
              <property name="text">
               <string>Show terminal size on resize</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="0" colspan="2">
+           <item row="19" column="0" colspan="2">
             <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
              <property name="toolTip">
               <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
@@ -477,6 +477,16 @@
             <widget class="QCheckBox" name="borderlessCheckBox">
              <property name="text">
               <string>&amp;Hide Window Borders</string>
+             </property>
+            </widget>
+           </item>
+           <item row="14" column="0" colspan="2">
+            <widget class="QCheckBox" name="closeTabOnMiddleClickCheckBox">
+             <property name="text">
+              <string>Close tab on middle-click</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
              </property>
             </widget>
            </item>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -111,7 +111,7 @@
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="20" column="1">
+           <item row="19" column="1">
             <widget class="QSpinBox" name="appTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -198,7 +198,7 @@
            <item row="2" column="1">
             <widget class="QComboBox" name="colorSchemaCombo"/>
            </item>
-           <item row="23" column="0">
+           <item row="22" column="0">
             <widget class="QLabel" name="label_9">
              <property name="text">
               <string>Start with preset:</string>
@@ -208,7 +208,7 @@
              </property>
             </widget>
            </item>
-           <item row="23" column="1">
+           <item row="22" column="1">
             <widget class="QComboBox" name="terminalPresetComboBox">
              <item>
               <property name="text">
@@ -242,7 +242,7 @@
              </property>
             </widget>
            </item>
-           <item row="24" column="0">
+           <item row="23" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Terminal margin</string>
@@ -259,7 +259,7 @@
              </property>
             </widget>
            </item>
-           <item row="22" column="0">
+           <item row="21" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
@@ -279,7 +279,7 @@
              </property>
             </widget>
            </item>
-           <item row="22" column="1">
+           <item row="21" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -306,7 +306,7 @@
            <item row="5" column="1">
             <widget class="QComboBox" name="tabsPos_comboBox"/>
            </item>
-           <item row="25" column="0" colspan="2">
+           <item row="24" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -339,7 +339,7 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
+           <item row="20" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Terminal transparency</string>
@@ -352,7 +352,7 @@
            <item row="6" column="1">
             <widget class="QComboBox" name="keybCursorShape_comboBox"/>
            </item>
-           <item row="20" column="0">
+           <item row="19" column="0">
             <widget class="QLabel" name="label_4">
              <property name="text">
               <string>Application transparency</string>
@@ -369,21 +369,21 @@
              </property>
             </widget>
            </item>
-           <item row="24" column="1">
+           <item row="23" column="1">
             <widget class="QSpinBox" name="terminalMarginSpinBox">
              <property name="suffix">
               <string>px</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="0" colspan="2">
+           <item row="17" column="0" colspan="2">
             <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
              <property name="text">
               <string>Enable bi-directional text support</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="1">
+           <item row="20" column="1">
             <widget class="QSpinBox" name="termTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -422,7 +422,7 @@
              </property>
             </widget>
            </item>
-           <item row="15" column="0" colspan="2">
+           <item row="14" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowTitleCheckBox">
              <property name="text">
               <string>Change window title based on current terminal</string>
@@ -439,21 +439,21 @@
            <item row="3" column="1">
             <widget class="QComboBox" name="styleComboBox"/>
            </item>
-           <item row="16" column="0" colspan="2">
+           <item row="15" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowIconCheckBox">
              <property name="text">
               <string>Change window icon based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="17" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
              <property name="text">
               <string>Show terminal size on resize</string>
              </property>
             </widget>
            </item>
-           <item row="19" column="0" colspan="2">
+           <item row="18" column="0" colspan="2">
             <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
              <property name="toolTip">
               <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
@@ -477,16 +477,6 @@
             <widget class="QCheckBox" name="borderlessCheckBox">
              <property name="text">
               <string>&amp;Hide Window Borders</string>
-             </property>
-            </widget>
-           </item>
-           <item row="14" column="0" colspan="2">
-            <widget class="QCheckBox" name="closeTabOnMiddleClickCheckBox">
-             <property name="text">
-              <string>Close tab on middle-click</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -575,7 +565,7 @@
               <string>Behavior</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_2">
-              <item row="11" column="0">
+              <item row="12" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>
@@ -585,7 +575,7 @@
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="2">
+              <item row="9" column="0" colspan="2">
                <layout class="QHBoxLayout" name="horizontalLayout_4">
                 <property name="spacing">
                  <number>5</number>
@@ -643,7 +633,7 @@
                 </item>
                </layout>
               </item>
-              <item row="10" column="1">
+              <item row="11" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -682,14 +672,14 @@
               <item row="2" column="1">
                <widget class="QComboBox" name="motionAfterPasting_comboBox"/>
               </item>
-              <item row="9" column="0" colspan="2">
+              <item row="10" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="10" column="0">
+              <item row="11" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
@@ -703,21 +693,31 @@
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="2">
+              <item row="8" column="0" colspan="2">
                <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
                 <property name="text">
                  <string>Save Size when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="2">
+              <item row="5" column="0" colspan="2"> 
+               <widget class="QCheckBox" name="closeTabOnMiddleClickCheckBox">
+                <property name="text">
+                 <string>Close tab on middle-click</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
                  <string>Ask for confirmation when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="11" column="1">
+              <item row="12" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
               <item row="0" column="0">
@@ -734,7 +734,7 @@
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="2">
+              <item row="7" column="0" colspan="2">
                <widget class="QCheckBox" name="savePosOnExitCheckBox">
                 <property name="text">
                  <string>Save Position when closing</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -113,10 +113,12 @@ void Properties::loadSettings()
     hideTabBarWithOneTab = m_settings->value(QLatin1String("HideTabBarWithOneTab"), false).toBool();
     m_motionAfterPaste = m_settings->value(QLatin1String("MotionAfterPaste"), 0).toInt();
 
-    /* fixed tab width */
+    /* fixed tabs width */
     fixedTabWidth = m_settings->value(QLatin1String("FixedTabWidth"), true).toBool();
     fixedTabWidthValue = m_settings->value(QLatin1String("FixedTabWidthValue"), 500).toInt();
+    /* tabs features */
     showCloseTabButton = m_settings->value(QLatin1String("ShowCloseTabButton"), true).toBool();
+    closeTabOnMiddleClick = m_settings->value(QLatin1String("CloseTabOnMiddleClick"), true).toBool();
 
     /* toggles */
     borderless = m_settings->value(QLatin1String("Borderless"), false).toBool();
@@ -223,6 +225,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("FixedTabWidth"), fixedTabWidth);
     m_settings->setValue(QLatin1String("FixedTabWidthValue"), fixedTabWidthValue);
     m_settings->setValue(QLatin1String("ShowCloseTabButton"), showCloseTabButton);
+    m_settings->setValue(QLatin1String("CloseTabOnMiddleClick"), closeTabOnMiddleClick);
 
     m_settings->setValue(QLatin1String("Borderless"), borderless);
     m_settings->setValue(QLatin1String("TabBarless"), tabBarless);

--- a/src/properties.h
+++ b/src/properties.h
@@ -76,6 +76,7 @@ class Properties
         int fixedTabWidthValue;
 
         bool showCloseTabButton;
+        bool closeTabOnMiddleClick;
 
         bool borderless;
         bool tabBarless;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -152,10 +152,12 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     tabsPos_comboBox->addItems(tabsPosList);
     tabsPos_comboBox->setCurrentIndex(Properties::Instance()->tabsPos);
 
-    /* tab width */
+    /* fixed tabs width */
     fixedTabWidthCheckBox->setChecked(Properties::Instance()->fixedTabWidth);
     fixedTabWidthSpinBox->setValue(Properties::Instance()->fixedTabWidthValue);
+    /* tabs features */
     closeTabButtonCheckBox->setChecked(Properties::Instance()->showCloseTabButton);
+    closeTabOnMiddleClickCheckBox->setChecked(Properties::Instance()->closeTabOnMiddleClick);
 
     /* keyboard cursor shape */
     QStringList keyboardCursorShapeList;
@@ -308,6 +310,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->fixedTabWidthValue = fixedTabWidthSpinBox->value();
     Properties::Instance()->keyboardCursorShape = keybCursorShape_comboBox->currentIndex();
     Properties::Instance()->showCloseTabButton = closeTabButtonCheckBox->isChecked();
+    Properties::Instance()->closeTabOnMiddleClick = closeTabOnMiddleClickCheckBox->isChecked();
     Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
     Properties::Instance()->noMenubarAccel = menuAccelCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -258,7 +258,7 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
 {
     QMouseEvent *e = reinterpret_cast<QMouseEvent*>(event);
     if (e->button() == Qt::MidButton) {
-        if (event->type() == QEvent::MouseButtonRelease) {
+        if (event->type() == QEvent::MouseButtonRelease && Properties::Instance()->closeTabOnMiddleClick) {
             // close the tab on middle clicking
             int index = tabBar()->tabAt(e->pos());
             if (index > -1){


### PR DESCRIPTION
It's too easy to close an important terminal when the middle button is also used to paste text.