### PR TITLE
Make color scheme dirs comply with XDG Base Directory Specification

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -20,6 +20,7 @@
 #include <QDesktopWidget>
 #include <QToolButton>
 #include <QMessageBox>
+#include <QStandardPaths>
 #include <QTimer>
 #include <functional>
 
@@ -531,6 +532,14 @@ void MainWindow::setup_ViewMenu_Actions()
 
 void MainWindow::setupCustomDirs()
 {
+    const QString appName = QCoreApplication::applicationName();
+    const QStringList dirs = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QLatin1String(),
+                                                       QStandardPaths::LocateDirectory);
+
+    for (const QString& dir : dirs)
+        TermWidgetImpl::addCustomColorSchemeDir(dir + QLatin1Char('/') + appName + QLatin1String("/color-schemes"));
+
+    // FIXME: To be deprecated and then removed
     const QSettings settings;
     const QString dir = QFileInfo(settings.fileName()).canonicalPath() + QStringLiteral("/color-schemes/");
     TermWidgetImpl::addCustomColorSchemeDir(dir);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -536,9 +536,9 @@ void MainWindow::setupCustomDirs()
     const QStringList dirs = QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QLatin1String(),
                                                        QStandardPaths::LocateDirectory);
 
-    for (const QString& dir : dirs)
+    for (const QString& dir : dirs) {
         TermWidgetImpl::addCustomColorSchemeDir(dir + QLatin1Char('/') + appName + QLatin1String("/color-schemes"));
-
+    }
     // FIXME: To be deprecated and then removed
     const QSettings settings;
     const QString dir = QFileInfo(settings.fileName()).canonicalPath() + QStringLiteral("/color-schemes/");


### PR DESCRIPTION
XDG_DATA_HOME AND XDG_DATA_DIRS are the place to store user and system
application data.
QStandardPaths::GenericDataLocation defaults:
Linux: `"~/.local/share", "/usr/local/share", "/usr/share"`
macOS: `"~/Library/Application Support", "/Library/Application Support"`

Reference:
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Edited: make HTML rendered from markdown better