### PR TITLE
Correctly emit signals

### DIFF
--- a/src/tab-switcher.cpp
+++ b/src/tab-switcher.cpp
@@ -178,7 +178,7 @@ void TabSwitcher::timer()
 void TabSwitcher::closeEvent(QCloseEvent *)
 {
     m_timer->stop();
-    activateTab(model()->data(model()->index(currentIndex().row(), 0), static_cast<int>(AppRole::Index)).value<int>());
+    Q_EMIT activateTab(model()->data(model()->index(currentIndex().row(), 0), static_cast<int>(AppRole::Index)).value<int>());
 }
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -169,7 +169,7 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 
 void TermWidgetImpl::zoomIn()
 {
-    emit QTermWidget::zoomIn();
+    QTermWidget::zoomIn();
 // note: do not save zoom here due the #74 Zoom reset option resets font back to Monospace
 //    Properties::Instance()->font = getTerminalFont();
 //    Properties::Instance()->saveSettings();
@@ -177,7 +177,7 @@ void TermWidgetImpl::zoomIn()
 
 void TermWidgetImpl::zoomOut()
 {
-    emit QTermWidget::zoomOut();
+    QTermWidget::zoomOut();
 // note: do not save zoom here due the #74 Zoom reset option resets font back to Monospace
 //    Properties::Instance()->font = getTerminalFont();
 //    Properties::Instance()->saveSettings();
@@ -237,7 +237,7 @@ void TermWidgetImpl::paste(QClipboard::Mode mode)
                 {
                     if (confirmation.buttonRole(btn) == QMessageBox::ActionRole && btn->text() == QMessageBox::tr("Show Details..."))
                     {
-                        btn->clicked();
+                        Q_EMIT btn->clicked();
                         break;
                     }
                 }

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -442,7 +442,7 @@ void TermWidgetHolder::closeTab()
     QTabWidget *parent = findParent<QTabWidget>(this);
     int idx = parent->indexOf(this);
     assert(idx != -1);
-    parent->tabCloseRequested(idx);
+    Q_EMIT parent->tabCloseRequested(idx);
 }
 
 #endif


### PR DESCRIPTION
Signals should be emitted with the emit/Q_EMIT keyword.
Non signals shouldn't use the emit keyword.