### PR TITLE
Support toggling bold font face for intense color

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -111,7 +111,7 @@
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="19" column="1">
+           <item row="20" column="1">
             <widget class="QSpinBox" name="appTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -188,7 +188,7 @@
              </layout>
             </widget>
            </item>
-           <item row="8" column="0" colspan="2">
+           <item row="9" column="0" colspan="2">
             <widget class="QCheckBox" name="showMenuCheckBox">
              <property name="text">
               <string>Show the menu bar</string>
@@ -198,7 +198,7 @@
            <item row="2" column="1">
             <widget class="QComboBox" name="colorSchemaCombo"/>
            </item>
-           <item row="22" column="0">
+           <item row="23" column="0">
             <widget class="QLabel" name="label_9">
              <property name="text">
               <string>Start with preset:</string>
@@ -208,7 +208,7 @@
              </property>
             </widget>
            </item>
-           <item row="22" column="1">
+           <item row="23" column="1">
             <widget class="QComboBox" name="terminalPresetComboBox">
              <item>
               <property name="text">
@@ -242,7 +242,7 @@
              </property>
             </widget>
            </item>
-           <item row="23" column="0">
+           <item row="24" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Terminal margin</string>
@@ -252,14 +252,14 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="11" column="0" colspan="2">
             <widget class="QCheckBox" name="hideTabBarCheckBox">
              <property name="text">
               <string>Hide tab bar with only one tab</string>
              </property>
             </widget>
            </item>
-           <item row="21" column="0">
+           <item row="22" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
@@ -306,7 +306,7 @@
            <item row="5" column="1">
             <widget class="QComboBox" name="tabsPos_comboBox"/>
            </item>
-           <item row="24" column="0" colspan="2">
+           <item row="25" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -319,7 +319,7 @@
              </property>
             </spacer>
            </item>
-           <item row="13" column="0" colspan="2">
+           <item row="14" column="0" colspan="2">
             <widget class="QCheckBox" name="closeTabButtonCheckBox">
              <property name="text">
               <string>Show close button on each tab</string>
@@ -339,7 +339,7 @@
              </property>
             </widget>
            </item>
-           <item row="20" column="0">
+           <item row="21" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Terminal transparency</string>
@@ -352,7 +352,7 @@
            <item row="6" column="1">
             <widget class="QComboBox" name="keybCursorShape_comboBox"/>
            </item>
-           <item row="19" column="0">
+           <item row="20" column="0">
             <widget class="QLabel" name="label_4">
              <property name="text">
               <string>Application transparency</string>
@@ -362,28 +362,28 @@
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
+           <item row="13" column="0" colspan="2">
             <widget class="QCheckBox" name="highlightCurrentCheckBox">
              <property name="text">
               <string>Show a border around the current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="23" column="1">
+           <item row="24" column="1">
             <widget class="QSpinBox" name="terminalMarginSpinBox">
              <property name="suffix">
               <string>px</string>
              </property>
             </widget>
            </item>
-           <item row="17" column="0" colspan="2">
+           <item row="18" column="0" colspan="2">
             <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
              <property name="text">
               <string>Enable bi-directional text support</string>
              </property>
             </widget>
            </item>
-           <item row="20" column="1">
+           <item row="21" column="1">
             <widget class="QSpinBox" name="termTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -399,7 +399,7 @@
              </property>
             </widget>
            </item>
-           <item row="11" column="1">
+           <item row="12" column="1">
             <widget class="QSpinBox" name="fixedTabWidthSpinBox">
              <property name="enabled">
               <bool>false</bool>
@@ -422,14 +422,14 @@
              </property>
             </widget>
            </item>
-           <item row="14" column="0" colspan="2">
+           <item row="15" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowTitleCheckBox">
              <property name="text">
               <string>Change window title based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="0">
+           <item row="12" column="0">
             <widget class="QCheckBox" name="fixedTabWidthCheckBox">
              <property name="text">
               <string>Fixed tab width:</string>
@@ -439,21 +439,21 @@
            <item row="3" column="1">
             <widget class="QComboBox" name="styleComboBox"/>
            </item>
-           <item row="15" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <widget class="QCheckBox" name="changeWindowIconCheckBox">
              <property name="text">
               <string>Change window icon based on current terminal</string>
              </property>
             </widget>
            </item>
-           <item row="16" column="0" colspan="2">
+           <item row="17" column="0" colspan="2">
             <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
              <property name="text">
               <string>Show terminal size on resize</string>
              </property>
             </widget>
            </item>
-           <item row="18" column="0" colspan="2">
+           <item row="19" column="0" colspan="2">
             <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
              <property name="toolTip">
               <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
@@ -463,7 +463,7 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="0" colspan="2">
+           <item row="8" column="0" colspan="2">
             <widget class="QCheckBox" name="menuAccelCheckBox">
              <property name="toolTip">
               <string>Accelerators are activated by Alt and can interfere with the terminal.</string>
@@ -473,7 +473,17 @@
              </property>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
+           <item row="7" column="0" colspan="2">
+            <widget class="QCheckBox" name="boldIntenseCheckBox">
+             <property name="toolTip">
+              <string>Toggles usage of bold font face for rendering intense colors</string>
+             </property>
+             <property name="text">
+              <string>Use bold font face for intense colors</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0" colspan="2">
             <widget class="QCheckBox" name="borderlessCheckBox">
              <property name="text">
               <string>&amp;Hide Window Borders</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -124,6 +124,7 @@ void Properties::loadSettings()
     borderless = m_settings->value(QLatin1String("Borderless"), false).toBool();
     tabBarless = m_settings->value(QLatin1String("TabBarless"), false).toBool();
     menuVisible = m_settings->value(QLatin1String("MenuVisible"), true).toBool();
+    boldIntense = m_settings->value(QLatin1String("BoldIntense"), true).toBool();
     noMenubarAccel = m_settings->value(QLatin1String("NoMenubarAccel"), true).toBool();
     askOnExit = m_settings->value(QLatin1String("AskOnExit"), true).toBool();
     saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
@@ -229,6 +230,7 @@ void Properties::saveSettings()
 
     m_settings->setValue(QLatin1String("Borderless"), borderless);
     m_settings->setValue(QLatin1String("TabBarless"), tabBarless);
+    m_settings->setValue(QLatin1String("BoldIntense"), boldIntense);
     m_settings->setValue(QLatin1String("NoMenubarAccel"), noMenubarAccel);
     m_settings->setValue(QLatin1String("MenuVisible"), menuVisible);
     m_settings->setValue(QLatin1String("AskOnExit"), askOnExit);

--- a/src/properties.h
+++ b/src/properties.h
@@ -78,6 +78,8 @@ class Properties
         bool showCloseTabButton;
         bool closeTabOnMiddleClick;
 
+        bool boldIntense;
+
         bool borderless;
         bool tabBarless;
         bool noMenubarAccel;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -167,6 +167,9 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     hideTabBarCheckBox->setChecked(Properties::Instance()->hideTabBarWithOneTab);
 
+    // bold font face for intense colors
+    boldIntenseCheckBox->setChecked(Properties::Instance()->boldIntense);
+
     // main menu bar
     menuAccelCheckBox->setChecked(Properties::Instance()->noMenubarAccel);
     showMenuCheckBox->setChecked(Properties::Instance()->menuVisible);
@@ -312,6 +315,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->showCloseTabButton = closeTabButtonCheckBox->isChecked();
     Properties::Instance()->closeTabOnMiddleClick = closeTabOnMiddleClickCheckBox->isChecked();
     Properties::Instance()->hideTabBarWithOneTab = hideTabBarCheckBox->isChecked();
+    Properties::Instance()->boldIntense = boldIntenseCheckBox->isChecked();
     Properties::Instance()->noMenubarAccel = menuAccelCheckBox->isChecked();
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();
     Properties::Instance()->borderless = borderlessCheckBox->isChecked();

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -101,6 +101,7 @@ void TermWidgetImpl::propertiesChanged()
     setTerminalBackgroundImage(Properties::Instance()->backgroundImage);
     setBidiEnabled(Properties::Instance()->enabledBidiSupport);
     setDrawLineChars(!Properties::Instance()->useFontBoxDrawingChars);
+    setBoldIntense(Properties::Instance()->boldIntense);
 
     /* be consequent with qtermwidget.h here */
     switch(Properties::Instance()->scrollBarPos) {


### PR DESCRIPTION
Depends on lxqt/qtermwidget#347

The defaults of qtermwidget's TerminalDisplay have the _boldIntense
property set to true.
Thus it renders all characters marked with "intense" color with a bold
font face.
Sometimes bold fonts reduce readability and some users just prefer to
avoid them.

Fixes #40

You can see it in action here: https://paste.foxxx0.de/X4WGhq/