### PR TITLE
Open new a tab to the right of the active tab

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -575,7 +575,7 @@
               <string>Behavior</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_2">
-              <item row="12" column="0">
+              <item row="13" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>
@@ -643,7 +643,7 @@
                 </item>
                </layout>
               </item>
-              <item row="11" column="1">
+              <item row="12" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -689,7 +689,17 @@
                 </property>
                </widget>
               </item>
-              <item row="11" column="0">
+              <item row="11" column="0" colspan="2">
+               <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
+                <property name="text">
+                 <string>Open new tab to the right of the active tab</string>
+                </property>
+                <property name="toolTip">
+                 <string>If unchecked the new tab will be opened as the rightmost tab</string>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
@@ -727,7 +737,7 @@
                 </property>
                </widget>
               </item>
-              <item row="12" column="1">
+              <item row="13" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
               <item row="0" column="0">
@@ -1008,6 +1018,7 @@
   <tabstop>savePosOnExitCheckBox</tabstop>
   <tabstop>saveSizeOnExitCheckBox</tabstop>
   <tabstop>useCwdCheckBox</tabstop>
+  <tabstop>openNewTabRightToActiveTabCheckBox</tabstop>
   <tabstop>emulationComboBox</tabstop>
   <tabstop>shortcutsWidget</tabstop>
   <tabstop>dropShowOnStartCheckBox</tabstop>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -130,6 +130,7 @@ void Properties::loadSettings()
     saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
     savePosOnExit = m_settings->value(QLatin1String("SavePosOnExit"), true).toBool();
     useCWD = m_settings->value(QLatin1String("UseCWD"), false).toBool();
+    m_openNewTabRightToActiveTab = m_settings->value(QLatin1String("OpenNewTabRightToActiveTab"), false).toBool();
     term = m_settings->value(QLatin1String("Term"), QLatin1String("xterm-256color")).toString();
     handleHistoryCommand = m_settings->value(QLatin1String("HandleHistory")).toString();
 
@@ -237,6 +238,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("SavePosOnExit"), savePosOnExit);
     m_settings->setValue(QLatin1String("SaveSizeOnExit"), saveSizeOnExit);
     m_settings->setValue(QLatin1String("UseCWD"), useCWD);
+    m_settings->setValue(QLatin1String("OpenNewTabRightToActiveTab"), m_openNewTabRightToActiveTab);
     m_settings->setValue(QLatin1String("Term"), term);
     m_settings->setValue(QLatin1String("HandleHistory"), handleHistoryCommand);
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -91,6 +91,7 @@ class Properties
         bool savePosOnExit;
 
         bool useCWD;
+        bool m_openNewTabRightToActiveTab;
 
         QString term;
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -211,6 +211,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     fixedHeightSpinBox->setValue(Properties::Instance()->fixedWindowSize.height());
 
     useCwdCheckBox->setChecked(Properties::Instance()->useCWD);
+    openNewTabRightToActiveTabCheckBox->setChecked(Properties::Instance()->m_openNewTabRightToActiveTab);
 
     termComboBox->setCurrentText(Properties::Instance()->term);
 
@@ -303,6 +304,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->prefDialogSize = size();
 
     Properties::Instance()->useCWD = useCwdCheckBox->isChecked();
+    Properties::Instance()->m_openNewTabRightToActiveTab = openNewTabRightToActiveTabCheckBox->isChecked();
 
     Properties::Instance()->term = termComboBox->currentText();
     Properties::Instance()->handleHistoryCommand = handleHistoryLineEdit->text();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -88,7 +88,9 @@ int TabWidget::addNewTab(TerminalConfig config)
     connect(console, &TermWidgetHolder::termTitleChanged, this, &TabWidget::onTermTitleChanged);
     connect(this, &QTabWidget::currentChanged, this, &TabWidget::currentTitleChanged);
 
-    int index = addTab(console, label);
+    const int newIndex = (Properties::Instance()->m_openNewTabRightToActiveTab ? currentIndex() + 1 : count());
+    const int index = insertTab(newIndex, console, label);
+
     console->setProperty(TAB_CUSTOM_NAME_PROPERTY, false);
     updateTabIndices();
     switchTab(index);


### PR DESCRIPTION
This pull request adds a new featuer to qterminal:

Open new a tab just to the right of the active tab

This feature is inspired by a similar feature in XFCE Terminal

The feature is by default off - meaning that the existing functionality is preserved - and the new tab will be opened as the rightmost tab
