### PR TITLE
Properties: Disables copy

### DIFF
--- a/src/properties.h
+++ b/src/properties.h
@@ -121,6 +121,9 @@ class Properties
         bool useFontBoxDrawingChars;
     private:
 
+        Properties(const Properties &) = delete;
+        Properties &operator=(const Properties &) = delete;
+
         int versionComparison(const QString &v1, const QString &v2);
 
         // Singleton handling
@@ -128,7 +131,6 @@ class Properties
         QString filename;
 
         explicit Properties(const QString& filename);
-        Properties(const Properties &) {};
 
         QSettings *m_settings;
 


### PR DESCRIPTION
Disables the use of copy constructors and assignment operators.
Properties is a singleton. Copy makes no sense.