### PR TITLE
Fixed shortcut setting when the Key column is sorted

### DIFF
--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -391,7 +391,12 @@ void PropertiesDialog::saveShortcuts()
         const QString& keyValue = shortcutKeys.at(x);
         QAction *keyAction = actions[keyValue];
 
-        QTableWidgetItem *item = shortcutsWidget->item(x, 1);
+        QTableWidgetItem *item = nullptr;
+        auto items = shortcutsWidget->findItems(tr(keyValue.toStdString().c_str()), Qt::MatchExactly);
+        if (!items.isEmpty())
+            item = shortcutsWidget->item(shortcutsWidget->row(items.at(0)), 1);
+        if (item == nullptr)
+            continue;
 
         QList<QKeySequence> shortcuts;
         const auto sequences = item->text().split(QLatin1Char('|'));


### PR DESCRIPTION
The bug was very old. I noticed it by chance.

Fixes https://github.com/lxqt/qterminal/issues/729