### PR TITLE
Fixed translation of shortcuts in Preferences

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,8 +176,14 @@ int main(int argc, char *argv[])
         QIcon::setThemeName(QStringLiteral("QTerminal"));
 
     // translations
-    QString fname = QString::fromLatin1("qterminal_%1.qm").arg(QLocale::system().name().left(5));
+
+    // install the translations built-into Qt itself
+    QTranslator qtTranslator;
+    qtTranslator.load(QStringLiteral("qt_") + QLocale::system().name(), QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+    app->installTranslator(&qtTranslator);
+
     QTranslator translator;
+    QString fname = QString::fromLatin1("qterminal_%1.qm").arg(QLocale::system().name().left(5));
 #ifdef TRANSLATIONS_DIR
     //qDebug() << "TRANSLATIONS_DIR: Loading translation file" << fname << "from dir" << TRANSLATIONS_DIR;
     /*qDebug() << "load success:" <<*/ translator.load(fname, QString::fromUtf8(TRANSLATIONS_DIR), QStringLiteral("_"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -687,8 +687,7 @@ void MainWindow::propertiesChanged()
         for (auto& action : menuBarActions)
         {
             QString txt = action->text();
-            txt.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*"))); // Chinese and Japanese
-            txt.remove(QLatin1Char('&')); // other languages
+            Properties::removeAccelerator(txt);
             action->setText(txt);
         }
     }

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -370,3 +370,11 @@ void Properties::migrate_settings()
         settings.setValue(QLatin1String("version"), currentVersion);
 }
 
+void Properties::removeAccelerator(QString& str)
+{
+    // Chinese, Japanese,...
+    str.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*")));
+    // other languages
+    str.remove(QLatin1Char('&'));
+}
+

--- a/src/properties.h
+++ b/src/properties.h
@@ -41,6 +41,8 @@ class Properties
         void loadSettings();
         void migrate_settings();
 
+        static void removeAccelerator(QString& str);
+
         QSize mainWindowSize;
         QSize fixedWindowSize;
         QSize prefDialogSize;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -401,8 +401,7 @@ void PropertiesDialog::saveShortcuts()
 
         QTableWidgetItem *item = nullptr;
         QString txt = keyAction->text();
-        txt.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*")));
-        txt.remove(QLatin1Char('&'));
+        Properties::removeAccelerator(txt);
         auto items = shortcutsWidget->findItems(txt, Qt::MatchExactly);
         if (!items.isEmpty())
             item = shortcutsWidget->item(shortcutsWidget->row(items.at(0)), 1);
@@ -439,8 +438,7 @@ void PropertiesDialog::setupShortcuts()
             sequenceStrings.append(shortcut.toString(QKeySequence::NativeText));
 
         QString txt = keyAction->text();
-        txt.remove(QRegularExpression(QStringLiteral("\\s*\\(&[a-zA-Z0-9]\\)\\s*")));
-        txt.remove(QLatin1Char('&'));
+        Properties::removeAccelerator(txt);
         QTableWidgetItem *itemName = new QTableWidgetItem(txt);
         QTableWidgetItem *itemShortcut = new QTableWidgetItem( sequenceStrings.join(QLatin1Char('|')) );
 

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -34,6 +34,9 @@ public:
     void pressKey(QKeyEvent *event) {
         QKeySequenceEdit::keyPressEvent(event);
     }
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
 };
 
 class Delegate : public QStyledItemDelegate


### PR DESCRIPTION
Also, worked around the Qt's bug about the Meta key by preventing multiple shortcuts.

Fixes https://github.com/lxqt/qterminal/issues/731

NOTE:

Actually, entering multiple shortcuts into `QKeySequenceEdit` can never result in multiple shortcuts but just creates a complex shortcut, all of whose elements should be pressed in a sequence. That's a small design flaw we have to tolerate.

That being said, (1) multiple shortcuts for a single action aren't very useful either because Qt only shows the first one in the main GUI, and (2) The separator `|` for multiple shortcuts isn't removed from the code because it can be used by editing the config file manually.