### PR TITLE
Fixed a mistake in settings dialog layout

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -279,7 +279,7 @@
              </property>
             </widget>
            </item>
-           <item row="21" column="1">
+           <item row="22" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>


### PR DESCRIPTION
The background image line-edit was hidden behind transparency spinbox!

@yan12125, do this and https://github.com/lxqt/qterminal/pull/732 (after it's completed) justify a point release?