### PR TITLE
unifying qterminal_ru.desktop

### DIFF
--- a/src/translations/qterminal_ru.desktop.yaml
+++ b/src/translations/qterminal_ru.desktop.yaml
@@ -1,1 +1,2 @@
+Desktop Entry/Comment: "Эмулятор терминала"
 Desktop Action Dropdown/Name: "Выпадающий терминал"

--- a/src/translations/qterminal_ru_RU.desktop.yaml
+++ b/src/translations/qterminal_ru_RU.desktop.yaml
@@ -1,1 +1,0 @@
-Desktop Entry/Comment: "Эмулятор терминала"


### PR DESCRIPTION
weblate:
Avoid having translation files for both the plain language code and its equivalent territory designation (for example de and de_DE).