### PR TITLE
Added swap Mouse Button 2 and 3 Option

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -151,6 +151,9 @@ void Properties::loadSettings()
     trimPastedTrailingNewlines = m_settings->value(QLatin1String("TrimPastedTrailingNewlines"), false).toBool();
 
     windowMaximized = m_settings->value(QLatin1String("LastWindowMaximized"), false).toBool();
+
+    SwapMouseButtons2and3 = m_settings->value(QLatin1String("SwapMouseButtons2and3"), false).toBool();
+
 }
 
 void Properties::saveSettings()
@@ -249,6 +252,9 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("TrimPastedTrailingNewlines"), trimPastedTrailingNewlines);
 
     m_settings->setValue(QLatin1String("LastWindowMaximized"), windowMaximized);
+
+    m_settings->setValue(QLatin1String("SwapMouseButtons2and3"), SwapMouseButtons2and3);
+
 }
 
 void Properties::migrate_settings()

--- a/src/properties.h
+++ b/src/properties.h
@@ -108,6 +108,8 @@ class Properties
         bool trimPastedTrailingNewlines;
 
         bool windowMaximized;
+	 
+	bool SwapMouseButtons2and3;
 
 
     private:

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -72,8 +72,17 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
 
     setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(this, &QWidget::customContextMenuRequested,
-            this, &TermWidgetImpl::customContextMenuCall);
+
+    if(Properties::Instance()->SwapMouseButtons2and3 == true)
+    {
+	connect(this, &QWidget::customContextMenuRequested,
+		this, &TermWidgetImpl::pasteSelection);
+    }
+    else
+    {
+	connect(this, &QWidget::customContextMenuRequested,
+		this, &TermWidgetImpl::customContextMenuCall);
+    }
 
     connect(this, &QTermWidget::urlActivated, this, &TermWidgetImpl::activateUrl);
 
@@ -262,9 +271,16 @@ bool TermWidget::eventFilter(QObject * /*obj*/, QEvent * ev)
         QMouseEvent *mev = (QMouseEvent *)ev;
         if ( mev->button() == Qt::MidButton )
         {
-            impl()->pasteSelection();
+	    if(Properties::Instance()->SwapMouseButtons2and3 == true)
+	    {
+		    const QPoint &point = (const QPoint &)(mev->pos());
+	            impl()->customContextMenuCall(point);
+	    }
+	    else  impl()->pasteSelection();
+
             return true;
         }
+
     }
     return false;
 }

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -48,9 +48,10 @@ class TermWidgetImpl : public QTermWidget
         void zoomReset();
         void pasteSelection();
         void pasteClipboard();
+	void customContextMenuCall(const QPoint & pos);
 
     private slots:
-        void customContextMenuCall(const QPoint & pos);
+        //void customContextMenuCall(const QPoint & pos);
         void activateUrl(const QUrl& url, bool fromContextMenu);
 };
 


### PR DESCRIPTION
If this would be intresting - i added a putty style mouse button option, you can swap middle and right button to have
same behaviour as in putty (paste with right mouse button, context menu middle button).
In config.ini one can now set SwapMouseButtons2and3=true to have button 2 and 3 functionality swapped.
regards