### PR TITLE
Use explicit QFlags default constructor instead of nullptr

### DIFF
--- a/src/third-party/qxtglobalshortcut.cpp
+++ b/src/third-party/qxtglobalshortcut.cpp
@@ -65,7 +65,7 @@ bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence& shortcut)
 {
     Qt::KeyboardModifiers allMods = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier;
     key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key((shortcut[0] ^ allMods) & shortcut[0]);
-    mods = shortcut.isEmpty() ? Qt::KeyboardModifiers(nullptr) : Qt::KeyboardModifiers(shortcut[0] & allMods);
+    mods = shortcut.isEmpty() ? Qt::KeyboardModifiers() : Qt::KeyboardModifiers(shortcut[0] & allMods);
     const quint32 nativeKey = nativeKeycode(key);
     const quint32 nativeMods = nativeModifiers(mods);
     const bool res = registerShortcut(nativeKey, nativeMods);
@@ -88,7 +88,7 @@ bool QxtGlobalShortcutPrivate::unsetShortcut()
     else
         qWarning() << "QxtGlobalShortcut failed to unregister:" << QKeySequence(key + mods).toString();
     key = Qt::Key(0);
-    mods = Qt::KeyboardModifiers(nullptr);
+    mods = Qt::KeyboardModifiers();
     return res;
 }
 


### PR DESCRIPTION
The use of nullptr is deprecated.