### PR TITLE
Removed two warnings that were shown when QTerminal started

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -124,7 +124,7 @@ public:
         for (const QStandardPaths::StandardLocation i : qAsConst(locations))
         {
             path = QStandardPaths::writableLocation(i);
-            if (!d.exists(path))
+            if (path.isEmpty() || !d.exists(path))
             {
                 continue;
             }
@@ -142,7 +142,7 @@ public:
         for (const QString &i : keys)
         {
             path = env.value(i);
-            if (!d.exists(path) || !QFileInfo(path).isDir())
+            if (path.isEmpty() || !d.exists(path) || !QFileInfo(path).isDir())
             {
                 continue;
             }


### PR DESCRIPTION
They were identical and would be seen if Qt warnings weren't suppressed (in ~/.config/QtProject/qtlogging.ini): "QDir::exists: Empty or null file name"