### PR TITLE
Added an option to disable bracketed paste mode

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -575,7 +575,7 @@
               <string>Behavior</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_2">
-              <item row="13" column="0">
+              <item row="14" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>
@@ -585,7 +585,7 @@
                 </property>
                </widget>
               </item>
-              <item row="9" column="0" colspan="2">
+              <item row="10" column="0" colspan="2">
                <layout class="QHBoxLayout" name="horizontalLayout_4">
                 <property name="spacing">
                  <number>5</number>
@@ -643,7 +643,7 @@
                 </item>
                </layout>
               </item>
-              <item row="12" column="1">
+              <item row="13" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -682,14 +682,14 @@
               <item row="2" column="1">
                <widget class="QComboBox" name="motionAfterPasting_comboBox"/>
               </item>
-              <item row="10" column="0" colspan="2">
+              <item row="11" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="11" column="0" colspan="2">
+              <item row="12" column="0" colspan="2">
                <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
                 <property name="text">
                  <string>Open new tab to the right of the active tab</string>
@@ -699,28 +699,28 @@
                 </property>
                </widget>
               </item>
-              <item row="12" column="0">
+              <item row="13" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0" colspan="2">
+              <item row="4" column="0" colspan="2">
                <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
                 <property name="text">
                  <string>Confirm multiline paste</string>
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="2">
+              <item row="9" column="0" colspan="2">
                <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
                 <property name="text">
                  <string>Save Size when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="2">
+              <item row="6" column="0" colspan="2">
                <widget class="QCheckBox" name="closeTabOnMiddleClickCheckBox">
                 <property name="text">
                  <string>Close tab on middle-click</string>
@@ -730,14 +730,14 @@
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="2">
+              <item row="7" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
                  <string>Ask for confirmation when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="13" column="1">
+              <item row="14" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
               <item row="0" column="0">
@@ -747,14 +747,14 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0" colspan="2">
+              <item row="5" column="0" colspan="2">
                <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
                 <property name="text">
                  <string>Trim trailing newlines in pasted text</string>
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="2">
+              <item row="8" column="0" colspan="2">
                <widget class="QCheckBox" name="savePosOnExitCheckBox">
                 <property name="text">
                  <string>Save Position when closing</string>
@@ -778,6 +778,13 @@
                <widget class="QRadioButton" name="historyUnlimited">
                 <property name="text">
                  <string>Unlimited history</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="disableBracketedPasteModeCheckBox">
+                <property name="text">
+                 <string>Forcefully disable bracketed paste mode</string>
                 </property>
                </widget>
               </item>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -112,6 +112,7 @@ void Properties::loadSettings()
     keyboardCursorShape = m_settings->value(QLatin1String("KeyboardCursorShape"), 0).toInt();
     hideTabBarWithOneTab = m_settings->value(QLatin1String("HideTabBarWithOneTab"), false).toBool();
     m_motionAfterPaste = m_settings->value(QLatin1String("MotionAfterPaste"), 0).toInt();
+    m_disableBracketedPasteMode = m_settings->value(QLatin1String("DisableBracketedPasteMode"), false).toBool();
 
     /* fixed tabs width */
     fixedTabWidth = m_settings->value(QLatin1String("FixedTabWidth"), true).toBool();
@@ -223,6 +224,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("KeyboardCursorShape"), keyboardCursorShape);
     m_settings->setValue(QLatin1String("HideTabBarWithOneTab"), hideTabBarWithOneTab);
     m_settings->setValue(QLatin1String("MotionAfterPaste"), m_motionAfterPaste);
+    m_settings->setValue(QLatin1String("DisableBracketedPasteMode"), m_disableBracketedPasteMode);
 
     m_settings->setValue(QLatin1String("FixedTabWidth"), fixedTabWidth);
     m_settings->setValue(QLatin1String("FixedTabWidthValue"), fixedTabWidthValue);

--- a/src/properties.h
+++ b/src/properties.h
@@ -73,6 +73,7 @@ class Properties
         int keyboardCursorShape;
         bool hideTabBarWithOneTab;
         int m_motionAfterPaste;
+        bool m_disableBracketedPasteMode;
 
         bool fixedTabWidth;
         int fixedTabWidthValue;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -191,6 +191,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     motionAfterPasting_comboBox->addItems(motionAfter);
     motionAfterPasting_comboBox->setCurrentIndex(Properties::Instance()->m_motionAfterPaste);
 
+    disableBracketedPasteModeCheckBox->setChecked(Properties::Instance()->m_disableBracketedPasteMode);
+
     // Setting windows style actions
     styleComboBox->addItem(tr("System Default"));
     styleComboBox->addItems(QStyleFactory::keys());
@@ -330,6 +332,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->menuVisible = showMenuCheckBox->isChecked();
     Properties::Instance()->borderless = borderlessCheckBox->isChecked();
     Properties::Instance()->m_motionAfterPaste = motionAfterPasting_comboBox->currentIndex();
+    Properties::Instance()->m_disableBracketedPasteMode = disableBracketedPasteModeCheckBox->isChecked();
 
     Properties::Instance()->historyLimited = historyLimited->isChecked();
     Properties::Instance()->historyLimitedTo = historyLimitedTo->value();

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -72,6 +72,7 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     }
 
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
+    disableBracketedPasteMode(Properties::Instance()->m_disableBracketedPasteMode);
 
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, &QWidget::customContextMenuRequested,
@@ -88,6 +89,7 @@ void TermWidgetImpl::propertiesChanged()
     setColorScheme(Properties::Instance()->colorScheme);
     setTerminalFont(Properties::Instance()->font);
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
+    disableBracketedPasteMode(Properties::Instance()->m_disableBracketedPasteMode);
     setTerminalSizeHint(Properties::Instance()->showTerminalSizeHint);
 
     if (Properties::Instance()->historyLimited)


### PR DESCRIPTION
Follows and depends on https://github.com/lxqt/qtermwidget/pull/390.

The bracketed paste mode may not be comfortable for all users — it's so different from what happens in text editors. Hence, an option to forcefully disable it.