### PR TITLE
Respect preset on opening new window and double clicking tabbar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -141,7 +141,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     /* The tab should be added after all changes are made to
        the main window; otherwise, the initial prompt might
        get jumbled because of changes in internal geometry. */
-    consoleTabulator->addNewTab(m_config);
+    addNewTab(m_config);
 }
 
 void MainWindow::rebuildActions()
@@ -834,9 +834,8 @@ void MainWindow::bookmarksDock_visibilityChanged(bool visible)
     Properties::Instance()->bookmarksVisible = visible;
 }
 
-void MainWindow::addNewTab()
+void MainWindow::addNewTab(TerminalConfig cfg)
 {
-    TerminalConfig cfg;
     if (Properties::Instance()->terminalsPreset == 3)
         consoleTabulator->preset4Terminals();
     else if (Properties::Instance()->terminalsPreset == 2)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -119,7 +119,7 @@ private slots:
     void bookmarksWidget_callCommand(const QString&);
     void bookmarksDock_visibilityChanged(bool visible);
 
-    void addNewTab();
+    void addNewTab(TerminalConfig cfg = TerminalConfig());
     void onCurrentTitleChanged(int index);
 
     void handleHistory();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -279,11 +279,17 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
         if (index == -1)
         {
             if (Properties::Instance()->terminalsPreset == 3)
+            {
                 preset4Terminals();
+            }
             else if (Properties::Instance()->terminalsPreset == 2)
+            {
                 preset2Vertical();
+            }
             else if (Properties::Instance()->terminalsPreset == 1)
+            {
                 preset2Horizontal();
+            }
             else
             {
                 TerminalConfig defaultConfig;

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -564,6 +564,8 @@ void TabWidget::preset4Terminals()
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
 
     // see preset2Horizontal() for an explanation
+    // Waiting for the first focus change is enough because, after it happens,
+    // the window is active and the other events happen serially.
     QObject::disconnect(mFocusConnection);
     mFocusConnection = connect(term, &TermWidgetHolder::termFocusChanged, this, [this, term] {
         QObject::disconnect(mFocusConnection);

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -64,7 +64,9 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
 }
 
 TabWidget::~TabWidget()
-{}
+{
+    QObject::disconnect(mFocusConnection);
+}
 
 TermWidgetHolder * TabWidget::terminalHolder()
 {
@@ -276,8 +278,17 @@ bool TabWidget::eventFilter(QObject *obj, QEvent *event)
         int index = tabBar()->tabAt(e->pos());
         if (index == -1)
         {
-            TerminalConfig defaultConfig;
-            addNewTab(defaultConfig);
+            if (Properties::Instance()->terminalsPreset == 3)
+                preset4Terminals();
+            else if (Properties::Instance()->terminalsPreset == 2)
+                preset2Vertical();
+            else if (Properties::Instance()->terminalsPreset == 1)
+                preset2Horizontal();
+            else
+            {
+                TerminalConfig defaultConfig;
+                addNewTab(defaultConfig);
+            }
         }
         else
             renameSession(index);
@@ -512,9 +523,16 @@ void TabWidget::preset2Horizontal()
     TerminalConfig defaultConfig;
     int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
+
+    // NOTE: When splitting happens, the focus changes. Therefore, we should switch to
+    // the 1st terminal only when the window is activated and the focus has really changed.
+    QObject::disconnect(mFocusConnection);
+    mFocusConnection = connect(term, &TermWidgetHolder::termFocusChanged, this, [this, term] {
+        QObject::disconnect(mFocusConnection);
+        term->directionalNavigation(NavigationDirection::Top);
+    });
+
     term->splitHorizontal(term->currentTerminal());
-    // switch to the 1st terminal
-    term->directionalNavigation(NavigationDirection::Left);
 }
 
 void TabWidget::preset2Vertical()
@@ -522,9 +540,15 @@ void TabWidget::preset2Vertical()
     TerminalConfig defaultConfig;
     int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
+
+    // see preset2Horizontal() for an explanation
+    QObject::disconnect(mFocusConnection);
+    mFocusConnection = connect(term, &TermWidgetHolder::termFocusChanged, this, [this, term] {
+        QObject::disconnect(mFocusConnection);
+        term->directionalNavigation(NavigationDirection::Left);
+    });
+
     term->splitVertical(term->currentTerminal());
-    // switch to the 1st terminal
-    term->directionalNavigation(NavigationDirection::Left);
 }
 
 void TabWidget::preset4Terminals()
@@ -532,13 +556,19 @@ void TabWidget::preset4Terminals()
     TerminalConfig defaultConfig;
     int ix = TabWidget::addNewTab(defaultConfig);
     TermWidgetHolder* term = reinterpret_cast<TermWidgetHolder*>(widget(ix));
-    term->splitVertical(term->currentTerminal());
-    term->splitHorizontal(term->currentTerminal());
-    term->directionalNavigation(NavigationDirection::Left);
 
-    term->splitHorizontal(term->currentTerminal());
-    // switch to the 1st terminal
-    term->directionalNavigation(NavigationDirection::Top);
+    // see preset2Horizontal() for an explanation
+    QObject::disconnect(mFocusConnection);
+    mFocusConnection = connect(term, &TermWidgetHolder::termFocusChanged, this, [this, term] {
+        QObject::disconnect(mFocusConnection);
+        term->splitHorizontal(term->currentTerminal());
+        term->directionalNavigation(NavigationDirection::Left);
+        term->splitHorizontal(term->currentTerminal());
+        // switch to the 1st terminal (the focus is already changed)
+        term->directionalNavigation(NavigationDirection::Top);
+    });
+
+    term->splitVertical(term->currentTerminal());
 }
 
 void TabWidget::showHideTabBar()

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -126,6 +126,8 @@ private:
     TabBar *mTabBar;
     QScopedPointer<TabSwitcher> mSwitcher;
     QList<QWidget*> mHistory;
+
+    QMetaObject::Connection mFocusConnection;
 };
 
 #endif

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -240,7 +240,7 @@ void TermWidgetHolder::directionalNavigation(NavigationDirection dir) {
             abs(poi.y() - contenderDims.topLeft.y()),
             abs(poi.y() - contenderDims.bottomRight.y())
         );
-        if (contenderDims.topLeft.x() > poi.x()) 
+        if (contenderDims.topLeft.x() > poi.x())
         {
             if (contenderDims.topLeft.x() > lowestX)
                 continue;
@@ -345,7 +345,7 @@ TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientati
     s->insertWidget(0, term);
 
     cfg.provideCurrentDirectory(term->impl()->workingDirectory());
-    
+
     TermWidget * w = newTerm(cfg);
     s->insertWidget(1, w);
     s->setSizes(sizes);
@@ -390,6 +390,7 @@ void TermWidgetHolder::setCurrentTerminal(TermWidget* term)
         {
             emit termTitleChanged(windowTitle(), QString{});
         }
+        emit termFocusChanged();
     }
 }
 

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -385,12 +385,12 @@ void TermWidgetHolder::setCurrentTerminal(TermWidget* term)
     {
         if (m_currentTerm->impl()->isTitleChanged())
         {
-            emit termTitleChanged(m_currentTerm->impl()->title(), m_currentTerm->impl()->icon());
+            Q_EMIT termTitleChanged(m_currentTerm->impl()->title(), m_currentTerm->impl()->icon());
         } else
         {
-            emit termTitleChanged(windowTitle(), QString{});
+            Q_EMIT termTitleChanged(windowTitle(), QString{});
         }
-        emit termFocusChanged();
+        Q_EMIT termFocusChanged();
     }
 }
 

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -87,6 +87,7 @@ class TermWidgetHolder : public QWidget
         void lastTerminalClosed();
         void renameSession();
         void termTitleChanged(QString title, QString icon) const;
+        void termFocusChanged();
 
     private:
         QString m_wdir;


### PR DESCRIPTION
Fixes https://github.com/lxqt/qterminal/issues/830 and fixes https://github.com/lxqt/qterminal/issues/351

The patch also fixes:

  * The problem about the focused terminal with horizontal/vertical splitting (it was wrong when a new window was opened); and
  * The issue in 4-terminal splitting.
