### PR TITLE
Added an option for keeping drop-down window open

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -893,6 +893,16 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
         </widget>
        </item>
        <item>
+        <widget class="QCheckBox" name="dropKeepOpenCheckBox">
+         <property name="toolTip">
+          <string>A lock button is shown on horizontal tab bar</string>
+         </property>
+         <property name="text">
+          <string>Keep window open when it loses focus</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>Size</string>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -167,6 +167,7 @@ void MainWindow::enableDropMode()
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
 
     m_dropLockButton = new QToolButton(this);
+    m_dropLockButton->setToolTip(tr("Keep window open when it loses focus"));
     consoleTabulator->setCornerWidget(m_dropLockButton, Qt::BottomRightCorner);
     m_dropLockButton->setCheckable(true);
     m_dropLockButton->connect(m_dropLockButton, &QToolButton::clicked, this, &MainWindow::setKeepOpen);
@@ -709,6 +710,8 @@ void MainWindow::propertiesChanged()
     }
 
     onCurrentTitleChanged(consoleTabulator->currentIndex());
+
+    setKeepOpen(Properties::Instance()->dropKeepOpen);
 
     realign();
 }

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -234,6 +234,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     historyLimitedTo->setValue(Properties::Instance()->historyLimitedTo);
 
     dropShowOnStartCheckBox->setChecked(Properties::Instance()->dropShowOnStart);
+    dropKeepOpenCheckBox->setChecked(Properties::Instance()->dropKeepOpen);
 
     dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
     dropHeightSpinBox->setMaximum(100);
@@ -345,6 +346,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->saveSettings();
 
     Properties::Instance()->dropShowOnStart = dropShowOnStartCheckBox->isChecked();
+    Properties::Instance()->dropKeepOpen = dropKeepOpenCheckBox->isChecked();
     Properties::Instance()->dropHeight = dropHeightSpinBox->value();
     Properties::Instance()->dropWidht = dropWidthSpinBox->value();
     Properties::Instance()->dropShortCut = QKeySequence(dropShortCutEdit->text());


### PR DESCRIPTION
It's useful when the lock button isn't shown (i.e., when tabbar is hidden or vertical).

Also added a tooltip for the lock button.

Closes https://github.com/lxqt/qterminal/issues/855