### PR TITLE
If Wayland environment is detected, QTerminal doesn't move window position on starting

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -23,7 +23,7 @@
 #include <QStandardPaths>
 #include <QTimer>
 #include <functional>
-#include <QProcessEnvironment>
+#include <QGuiApplication>
 
 #ifdef HAVE_QDBUS
 #include <QtDBus/QtDBus>
@@ -117,7 +117,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
             resize(Properties::Instance()->fixedWindowSize);
         }
         if (Properties::Instance()->savePosOnExit && !Properties::Instance()->mainWindowPosition.isNull()
-            && QProcessEnvironment::systemEnvironment().value(QStringLiteral("XDG_SESSION_TYPE")) != QStringLiteral("wayland")
+            && QGuiApplication::platformName() != QStringLiteral("wayland")
             ) {
             move(Properties::Instance()->mainWindowPosition);
         }


### PR DESCRIPTION
This fixes the wrong position of menus. If you work on Wayland environment and save the Qt window position and move the window position to save one on application start, menus will be shown in the wrong position:
![2021-10-11_08:50:54](https://user-images.githubusercontent.com/1163139/136745105-d193024c-f886-47ca-a4d8-5bd831cf5a20.png)
There is a vertical gap that increases every time you close and open the application.
Finally, the menu is drawn outside of the screen and it cannot be used.

It is easy to avoid: Don't move window position on starting.

Maybe this is not a LXQt bug, it is a bug of Qt, but it is really annoying.
