### PR TITLE
Fixed max. value of drop-down width/height spin-box

### DIFF
--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -236,10 +236,10 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropShowOnStartCheckBox->setChecked(Properties::Instance()->dropShowOnStart);
     dropKeepOpenCheckBox->setChecked(Properties::Instance()->dropKeepOpen);
 
-    dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
     dropHeightSpinBox->setMaximum(100);
-    dropWidthSpinBox->setValue(Properties::Instance()->dropWidht);
     dropWidthSpinBox->setMaximum(100);
+    dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
+    dropWidthSpinBox->setValue(Properties::Instance()->dropWidht);
 
     dropShortCutEdit->setText(Properties::Instance()->dropShortCut.toString());
 


### PR DESCRIPTION
It seemed like a copy-paste typo.

Fixes https://github.com/lxqt/qterminal/issues/874