### PR TITLE
Enable bookmark filtering

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -349,7 +349,9 @@ QModelIndexList BookmarksModel::allChildRows(const QModelIndex& parent) const
         auto child = index(row, 0, parent); // we only need the row
         list << child;
         if (hasChildren(child))
+        {
             list << allChildRows(child);
+        }
     }
     return list;
 }
@@ -424,7 +426,9 @@ void BookmarksWidget::filter(const QString& str)
                 treeView->setRowHidden(index.row(), index.parent(), false);
             }
             else
+            {
                 treeView->setRowHidden(index.row(), index.parent(), true);
+            }
         }
     }
 }

--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -341,6 +341,19 @@ int BookmarksModel::rowCount(const QModelIndex &parent) const
     return parentItem->childCount();
 }
 
+QModelIndexList BookmarksModel::allChildRows(const QModelIndex& parent) const
+{
+    QModelIndexList list;
+    for (int row = 0; row < rowCount(parent); ++row)
+    {
+        auto child = index(row, 0, parent); // we only need the row
+        list << child;
+        if (hasChildren(child))
+            list << allChildRows(child);
+    }
+    return list;
+}
+
 #if 0
 bool BookmarksModel::setData(const QModelIndex &index, const QVariant &value,
                              int role)
@@ -370,6 +383,8 @@ BookmarksWidget::BookmarksWidget(QWidget *parent)
 
     connect(treeView, &QTreeView::activated,
             this, &BookmarksWidget::handleCommand);
+    connect(filterEdit, &QLineEdit::textChanged,
+            this, &BookmarksWidget::filter);
 }
 
 BookmarksWidget::~BookmarksWidget()
@@ -392,4 +407,24 @@ void BookmarksWidget::handleCommand(const QModelIndex& index)
         return;
 
     emit callCommand(item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
+}
+
+void BookmarksWidget::filter(const QString& str)
+{
+    treeView->clearSelection();
+    const QModelIndexList list = m_model->allChildRows(QModelIndex());
+    for (const auto& index : list)
+    {
+        AbstractBookmarkItem *item = static_cast<AbstractBookmarkItem*>(index.internalPointer());
+        if (item && item->type() == AbstractBookmarkItem::Command)
+        {
+            if (item->value().contains(str, Qt::CaseInsensitive)
+                || item->display().contains(str, Qt::CaseInsensitive))
+            {
+                treeView->setRowHidden(index.row(), index.parent(), false);
+            }
+            else
+                treeView->setRowHidden(index.row(), index.parent(), true);
+        }
+    }
 }

--- a/src/bookmarkswidget.h
+++ b/src/bookmarkswidget.h
@@ -43,6 +43,7 @@ private:
 
 private slots:
     void handleCommand(const QModelIndex& index);
+    void filter(const QString& str);
 };
 
 
@@ -66,6 +67,8 @@ public:
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QModelIndexList allChildRows(const QModelIndex& parent) const;
 
 private:
     AbstractBookmarkItem *getItem(const QModelIndex &index) const;

--- a/src/forms/bookmarkswidget.ui
+++ b/src/forms/bookmarkswidget.ui
@@ -34,7 +34,11 @@
     </widget>
    </item>
    <item row="0" column="1">
-    <widget class="QLineEdit" name="filterEdit"/>
+    <widget class="QLineEdit" name="filterEdit">
+     <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QTreeView" name="treeView">


### PR DESCRIPTION
Filtering did nothing before.

NOTE: This patch only enables bookmark filtering. The filter line-edit needs to be focused when the bookmark pane is shown; some other changes may also be needed. I'll make another PR after this one is reviewed and merged.