### PR TITLE
Cleaned up bookmarks tree

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -18,6 +18,7 @@
 
 #include <QDebug>
 #include <QStandardPaths>
+#include <QShortcut>
 
 #include "bookmarkswidget.h"
 #include "properties.h"
@@ -98,58 +99,6 @@ public:
         : AbstractBookmarkItem(AbstractBookmarkItem::Group, parent)
     {
         m_display = name;
-    }
-};
-
-class BookmarkLocalGroupItem : public BookmarkGroupItem
-{
-public:
-    BookmarkLocalGroupItem(AbstractBookmarkItem *parent)
-        : BookmarkGroupItem(QObject::tr("Local Bookmarks"), parent)
-    {
-        QList<QStandardPaths::StandardLocation> locations;
-        locations << QStandardPaths::DesktopLocation
-                  << QStandardPaths::DocumentsLocation
-                  << QStandardPaths::TempLocation
-                  << QStandardPaths::HomeLocation
-                  << QStandardPaths::MusicLocation
-                  << QStandardPaths::PicturesLocation;
-
-        QString path;
-        QString name;
-        QString cmd;
-        QDir d;
-
-        // standard $HOME subdirs
-        for (const QStandardPaths::StandardLocation i : qAsConst(locations))
-        {
-            path = QStandardPaths::writableLocation(i);
-            if (path.isEmpty() || !d.exists(path))
-            {
-                continue;
-            }
-            name = QStandardPaths::displayName(i);
-
-            path.replace(QLatin1String(" "), QLatin1String("\\ "));
-            cmd = QLatin1String("cd ") + path;
-
-            addChild(new BookmarkCommandItem(name, cmd, this));
-        }
-
-        // system env - include dirs in the tree
-        QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-        const auto keys = env.keys();
-        for (const QString &i : keys)
-        {
-            path = env.value(i);
-            if (path.isEmpty() || !d.exists(path) || !QFileInfo(path).isDir())
-            {
-                continue;
-            }
-            path.replace(QLatin1String(" "), QLatin1String("\\ "));
-            cmd = QLatin1String("cd ") + path;
-            addChild(new BookmarkCommandItem(i, cmd, this));
-        }
     }
 };
 
@@ -248,7 +197,6 @@ void BookmarksModel::setup()
     if (m_root)
         delete m_root;
     m_root = new BookmarkRootItem();
-    m_root->addChild(new BookmarkLocalGroupItem(m_root));
     m_root->addChild(new BookmarkFileGroupItem(m_root, Properties::Instance()->bookmarksFile));
     beginResetModel();
     endResetModel();
@@ -382,11 +330,17 @@ BookmarksWidget::BookmarksWidget(QWidget *parent)
     m_model = new BookmarksModel(this);
     treeView->setModel(m_model);
     treeView->header()->hide();
+    setFocusProxy(filterEdit);
 
     connect(treeView, &QTreeView::activated,
             this, &BookmarksWidget::handleCommand);
     connect(filterEdit, &QLineEdit::textChanged,
             this, &BookmarksWidget::filter);
+
+    QShortcut *clearFilter = new QShortcut(QKeySequence (Qt::Key_Escape), this);
+    connect(clearFilter, &QShortcut::activated, this, [this] {
+        filterEdit->clear();
+    });
 }
 
 BookmarksWidget::~BookmarksWidget()
@@ -397,6 +351,7 @@ void BookmarksWidget::setup()
 {
     m_model->setup();
 
+    treeView->setRootIndex(m_model->index(0, 0)); // do not show BookmarkFileGroupItem's top branch
     treeView->expandAll();
     treeView->resizeColumnToContents(0);
     treeView->resizeColumnToContents(1);

--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -17,7 +17,6 @@
  ***************************************************************************/
 
 #include <QDebug>
-#include <QStandardPaths>
 #include <QShortcut>
 
 #include "bookmarkswidget.h"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -589,6 +589,10 @@ void MainWindow::testClose(bool removeFinished)
 void MainWindow::toggleBookmarks()
 {
     m_bookmarksDock->toggleViewAction()->trigger();
+    if (m_bookmarksDock->isVisible())
+    {
+        m_bookmarksDock->widget()->setFocus();
+    }
 }
 
 


### PR DESCRIPTION
This small patch

 * Removes hard-coded bookmarks;
 * Makes the top branch "Bookmarks" hidden;
 * Focuses the filtering line-edit on showing the bookmarks dock (inside the main window); and
 * Clears the filtering line-edit on pressing Escape inside the dock.