### PR TITLE
No hidden parent for dropdown window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,8 +213,7 @@ MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg)
     MainWindow *window = nullptr;
     if (dropMode)
     {
-        QWidget *hiddenPreviewParent = new QWidget(nullptr, Qt::Tool);
-        window = new MainWindow(cfg, dropMode, hiddenPreviewParent);
+        window = new MainWindow(cfg, dropMode);
         if (Properties::Instance()->dropShowOnStart)
             window->show();
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -674,9 +674,9 @@ void MainWindow::actAbout_triggered()
 
 void MainWindow::actProperties_triggered()
 {
-    PropertiesDialog *p = new PropertiesDialog(this);
-    connect(p, &PropertiesDialog::propertiesChanged, this, &MainWindow::propertiesChanged);
-    p->exec();
+    PropertiesDialog p(this);
+    connect(&p, &PropertiesDialog::propertiesChanged, this, &MainWindow::propertiesChanged);
+    p.exec();
 }
 
 void MainWindow::propertiesChanged()


### PR DESCRIPTION
The code had made the dropdown window be the child of a hidden tool window. I have no idea why the original coder thought that a main window needed a hidden parent. However, for some reason (perhaps deep in Qt code), that hidden parent caused trouble with sub-dialogs of the properties dialog and made the app exit after closing them. So, it's removed here.

Also, a memory leak is fixed in showing the properties dialog — previously, it wasn't destroyed until the app exited.

Fixes https://github.com/lxqt/qterminal/issues/894