### PR TITLE
Fixed closing of last tab with prompt

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -68,7 +68,6 @@ MainWindow::MainWindow(TerminalConfig &cfg,
 #ifdef HAVE_QDBUS
     registerAdapter<WindowAdaptor, MainWindow>(this);
 #endif
-    m_removeFinished = false;
     QTerminalApp::Instance()->addWindow(this);
     // We want terminal translucency...
     setAttribute(Qt::WA_TranslucentBackground);
@@ -125,7 +124,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     }
 
     consoleTabulator->setAutoFillBackground(true);
-    connect(consoleTabulator, &TabWidget::closeTabNotification, this, &MainWindow::testClose);
+    connect(consoleTabulator, &TabWidget::closeLastTabNotification, this, &MainWindow::close);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     //consoleTabulator->setShellProgram(command);
 
@@ -580,12 +579,6 @@ void MainWindow::showFullscreen(bool fullscreen)
         setWindowState(windowState() & ~Qt::WindowFullScreen);
 }
 
-void MainWindow::testClose(bool removeFinished)
-{
-
-    m_removeFinished = removeFinished;
-    close();
-}
 void MainWindow::toggleBookmarks()
 {
     m_bookmarksDock->toggleViewAction()->trigger();
@@ -646,12 +639,6 @@ void MainWindow::closeEvent(QCloseEvent *ev)
         }
         ev->accept();
     } else {
-        if(m_removeFinished) {
-            QWidget *w = consoleTabulator->widget(consoleTabulator->count()-1);
-            consoleTabulator->removeTab(consoleTabulator->count()-1);
-            delete w; // delete the widget because the window isn't closed
-            m_removeFinished = false;
-        }
         ev->ignore();
     }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -63,7 +63,6 @@ private:
     QWidget *settingOwner;
 
     QMenu *presetsMenu;
-    bool m_removeFinished;
     TerminalConfig m_config;
 
     QDockWidget *m_bookmarksDock;
@@ -105,7 +104,6 @@ private slots:
     void actAbout_triggered();
     void actProperties_triggered();
     void updateActionGroup(QAction *);
-    void testClose(bool removeFinished);
     void toggleBookmarks();
     void toggleBorderless();
     void toggleTabBar();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -311,8 +311,6 @@ void TabWidget::removeFinished()
     {
         int index = prop.toInt();
         removeTab(index);
-//        if (count() == 0)
-//            emit closeTabNotification();
     }
 }
 
@@ -336,7 +334,7 @@ void TabWidget::removeTab(int index)
     //    tabNumerator--;
         setUpdatesEnabled(true);
     } else {
-        emit closeTabNotification(true);
+        emit closeLastTabNotification();
     }
 
     renameTabsAfterRemove();
@@ -379,7 +377,7 @@ void TabWidget::removeCurrentTab()
     if (count() > 1) {
         removeTab(currentIndex());
     } else {
-        emit closeTabNotification(false);
+        emit closeLastTabNotification();
     }
 }
 

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -98,7 +98,7 @@ public slots:
     void switchToNext();
     void switchToPrev();
 signals:
-    void closeTabNotification(bool);
+    void closeLastTabNotification();
     void tabRenameRequested(int);
     void tabTitleColorChangeRequested(int);
     void currentTitleChanged(int);


### PR DESCRIPTION
There were a few odd inconsistencies and a dangerous situation regarding tabs:

 1. If the close button of the last tab was pressed and the exit prompt was rejected, a state would happen, in which the terminal window had no tab. That could easily result in a crash if the user called an action that was related to the active terminal (like "Clear Active Terminal" from the menu bar).
 2. Moreover, in the above-mentioned state, it was impossible to add a new tab by using the shortcut.
 3. With a single tab, if the "Close Tab" action was used from the menu bar — instead of the tab's close button — and the exit prompt was rejected, the tab wouldn't be removed. That was actually a good behavior but it was inconsistent with 1.

This patch removes the inconsistencies and avoids the crash danger by choosing 3 as the only behavior. In other words, closing the last tab is exactly like closing the window, with or without the exit prompt. A tabless terminal is also made impossible.

Fixes https://github.com/lxqt/qterminal/issues/897