### PR TITLE
Never show close prompt when explicitly ending session from terminal

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -592,7 +592,9 @@ void MainWindow::toggleBookmarks()
 void MainWindow::closeEvent(QCloseEvent *ev)
 {
     if (!Properties::Instance()->askOnExit
-        || !consoleTabulator->count())
+        || consoleTabulator->count() == 0
+        // the session is ended explicitly (e.g., by ctrl-d); prompt doesn't make sense
+        || consoleTabulator->terminalHolder()->findChildren<TermWidget*>().count() == 0)
     {
         // #80 - do not save state and geometry in drop mode
         if (!m_dropMode) {


### PR DESCRIPTION
Because, for example, it doesn't make sense to show a prompt after `ctrl-d`. Showing a prompt in this case would result in a blank view, that is prone to crash. The close prompt is for the GUI.

Fixes https://github.com/lxqt/qterminal/issues/904