### PR TITLE
Use a shortcut entry for drop-down shortcut

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -953,19 +953,13 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
         </widget>
        </item>
        <item>
-        <layout class="QFormLayout" name="formLayout_2">
+        <layout class="QFormLayout" name="dropShortCutFormLayout">
          <item row="0" column="0">
           <widget class="QLabel" name="dropShortCutLabel">
            <property name="text">
             <string>Shortcut:</string>
            </property>
-           <property name="buddy">
-            <cstring>dropShortCutEdit</cstring>
-           </property>
           </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QLineEdit" name="dropShortCutEdit"/>
          </item>
         </layout>
        </item>

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -62,6 +62,8 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         PropertiesDialog(QWidget *parent=nullptr);
         ~PropertiesDialog() override;
 
+        bool eventFilter(QObject *object, QEvent *event) override;
+
     signals:
         void propertiesChanged();
 
@@ -69,6 +71,8 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         void setFontSample(const QFont & f);
         void openBookmarksFile(const QString &fname);
         void saveBookmarksFile(const QString &fname);
+
+        KeySequenceEdit *dropShortCutEdit;
 
     private slots:
         void apply();


### PR DESCRIPTION
In this way, the user doesn't need to worry about key names.

The entry reacts to `Enter/Return` as well as `Escape` like other entries (spin-boxes and line-edits): `Enter/Return` applies the changes and closes the Preferences dialog, while `Escape` cancels everything and closes the dialog.