### PR TITLE
Set example file, improved template text, use namefilter for *.xml

### DIFF
--- a/qterminal_bookmarks_example.xml
+++ b/qterminal_bookmarks_example.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Some examples to demonstrate how the use of QTerminal bookmarks. Adjust them to fit your needs. -->
+<!-- Some examples to demonstrate how to use QTerminal bookmarks. 
+Adjust them to fit your needs. -->
 <qterminal>
 <group name="Base">
     <command name="Open in Filemanager" value="xdg-open $(pwd)"/>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -1,3 +1,4 @@
+
 /***************************************************************************
  *   Copyright (C) 2010 by Petr Vanek                                      *
  *   petr@scribus.info                                                     *
@@ -140,7 +141,7 @@ void Properties::loadSettings()
     // bookmarks
     useBookmarks = m_settings->value(QLatin1String("UseBookmarks"), false).toBool();
     bookmarksVisible = m_settings->value(QLatin1String("BookmarksVisible"), true).toBool();
-    const QString s = QFileInfo(m_settings->fileName()).canonicalPath() + QString::fromLatin1("/qterminal_bookmarks.xml");
+    const QString s = QFileInfo(m_settings->fileName()).canonicalPath() + QString::fromLatin1("/qterminal_bookmarks_example.xml");
     bookmarksFile = m_settings->value(QLatin1String("BookmarksFile"), s).toString();
 
     terminalsPreset = m_settings->value(QLatin1String("TerminalsPreset"), 0).toInt();

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -469,9 +469,9 @@ void PropertiesDialog::setupShortcuts()
 
 void PropertiesDialog::bookmarksButton_clicked()
 {
-    QFileDialog dia(this, tr("Open or create bookmarks file"));
+    QFileDialog dia(this, tr("Select bookmarks file"));
     dia.setOption(QFileDialog::DontConfirmOverwrite, true);
-    dia.setFileMode(QFileDialog::AnyFile);
+    dia.setNameFilter(tr("*.xml files (*.xml)"));
     if (!dia.exec())
         return;
 
@@ -488,7 +488,7 @@ void PropertiesDialog::openBookmarksFile(const QString &fname)
     QFile f(fname);
     QString content;
     if (!f.open(QFile::ReadOnly))
-        content = QString::fromLatin1("<qterminal>\n  <group name=\"group1\">\n    <command name=\"cmd1\" value=\"cd $HOME\"/>\n  </group>\n</qterminal>");
+        content = QString::fromLatin1("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<!-- Syntax for bookmarks file-->\n<qterminal>\n  <group name=\"group 1\">\n    <command name=\"temp\" value=\"cd /tmp\"/>\n    <command name=\"Other command\" value=\"command\"/>\n  </group>\n</qterminal>");
     else
         content = QString::fromUtf8(f.readAll());
 


### PR DESCRIPTION
At least 2 things missing I've no clue how to achieve:
* set filedialog path to ` ~/.config/qterminal.org/` instead of` $HOME`
* save `qterminal_bookmarks_example.xml` in the config location at first run

As it is it will show the small example syntax when `qterminal_bookmarks_example.xml ` is not present.
With the above it would close https://github.com/lxqt/qterminal/issues/886 IMHO