### PR TITLE
Improved the Bookmarks page of QTerminal's settings dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ if(X11_FOUND)
     target_link_libraries(${EXE_NAME} ${X11_X11_LIB})
 endif()
 
+set(APP_DIR "${CMAKE_INSTALL_FULL_DATADIR}/qterminal")
+add_definitions(-DAPP_DIR=\"${APP_DIR}\")
 
 install(FILES
     ${DESKTOP_FILES}
@@ -229,7 +231,7 @@ install(FILES
 
 install(FILES
     qterminal_bookmarks_example.xml
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/qterminal"
+    DESTINATION ${APP_DIR}
 )
 
 if(NOT APPLEBUNDLE)

--- a/qterminal_bookmarks_example.xml
+++ b/qterminal_bookmarks_example.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Some examples to demonstrate how the use of QTerminal bookmarks. Adjust them to fit your needs. -->
+<!-- Some examples to demonstrate how to use QTerminal bookmarks.
+Adjust them to fit your needs. -->
 <qterminal>
 <group name="Base">
     <command name="Open in Filemanager" value="xdg-open $(pwd)"/>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -1010,7 +1010,7 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
         </widget>
        </item>
        <item row="1" column="0">
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QHBoxLayout" name="FindBookmarkLayout">
          <item>
           <widget class="QLabel" name="label_10">
            <property name="text">

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -383,3 +383,8 @@ void Properties::removeAccelerator(QString& str)
     str.remove(QLatin1Char('&'));
 }
 
+QString Properties::configDir() const
+{
+    return QFileInfo(m_settings->fileName()).absoluteDir().canonicalPath();
+}
+

--- a/src/properties.h
+++ b/src/properties.h
@@ -40,6 +40,7 @@ class Properties
         void saveSettings();
         void loadSettings();
         void migrate_settings();
+        QString configDir() const;
 
         static void removeAccelerator(QString& str);
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -497,13 +497,18 @@ void PropertiesDialog::bookmarksButton_clicked()
 {
     QFileDialog dia(this, tr("Open bookmarks file"));
     dia.setFileMode(QFileDialog::ExistingFile);
-    dia.setNameFilter(tr("XML files (*.xml)"));
+    QString xmlStr = tr("XML files (*.xml)");
+    QString allStr = tr("All files (*)");
+    dia.setNameFilters(QStringList() << xmlStr << allStr);
 
     bool openAppDir(QObject::sender() != bookmarksButton);
     if (!openAppDir) {
         // if the path exists, select it; otherwise, open the app directory
         auto path = bookmarksLineEdit->text();
         if (!path.isEmpty() && QFile::exists(path)) {
+            if (!path.endsWith(QLatin1String(".xml"))) {
+                dia.selectNameFilter(allStr);
+            }
             dia.selectFile(path);
         }
         else {
@@ -589,10 +594,15 @@ void PropertiesDialog::saveBookmarksFile()
     QFile f(fname);
 
     // first show a prompt message if needed
-    if (fromAppDir && f.exists()) {
-        QMessageBox::StandardButton btn =
-        QMessageBox::question(this, tr("Question"), tr("Do you want to overwrite this bookmarks file?")
-                                                    + QLatin1String("\n%1").arg(fname));
+    if (f.exists()) {
+        QMessageBox::StandardButton btn = QMessageBox::Yes;
+        if (fromAppDir) {
+            btn = QMessageBox::question(this, tr("Question"), tr("Do you want to overwrite this bookmarks file?")
+                                                              + QLatin1String("\n%1").arg(fname));
+        }
+        else if (!fname.endsWith(QLatin1String(".xml"))) {
+            btn =  QMessageBox::question(this, tr("Question"), tr("The name of bookmarks file does not end with '.xml'.\nAre you sure that you want to overwrite it?"));
+        }
         if (btn == QMessageBox::No) {
             return;
         }

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -257,7 +257,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
             this, &PropertiesDialog::bookmarksButton_clicked);
     exampleBookmarksButton = nullptr;
 #ifdef APP_DIR
-    exampleBookmarksButton = new QPushButton(QLatin1String("Examples"));
+    exampleBookmarksButton = new QPushButton(tr("Examples"));
     FindBookmarkLayout->addWidget(exampleBookmarksButton);
     connect(exampleBookmarksButton, &QPushButton::clicked,
             this, &PropertiesDialog::bookmarksButton_clicked);

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -21,6 +21,7 @@
 
 #include <QStyledItemDelegate>
 #include <QKeySequenceEdit>
+#include <QPushButton>
 #include "ui_propertiesdialog.h"
 
 class KeySequenceEdit : public QKeySequenceEdit
@@ -69,10 +70,11 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
 
     private:
         void setFontSample(const QFont & f);
-        void openBookmarksFile(const QString &fname);
-        void saveBookmarksFile(const QString &fname);
+        void openBookmarksFile();
+        void saveBookmarksFile();
 
         KeySequenceEdit *dropShortCutEdit;
+        QPushButton *exampleBookmarksButton;
 
     private slots:
         void apply();
@@ -80,6 +82,7 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
 
         void changeFontButton_clicked();
         void chooseBackgroundImageButton_clicked();
+        void bookmarksPathEdited();
         void bookmarksButton_clicked();
 
     protected:


### PR DESCRIPTION
In short, this patch makes all widgets of the Bookmarks page work as expected. What follows is about details.

The default XML text is saved to a bookmarks file inside the user's config directory the first time he clicks the "Apply" or "OK" button of QTerminal's settings dialog.

An "Examples" button is added. It opens the app directory, which contains example bookmarks file(s). Also, if the path inside the line-edit is nonexistent, the same directory will be opened by clicking the "Find..." button; otherwise, the path will be selected in the file dialog.

If the user chooses an example bookmarks file from the app directory, it'll be copied to his config directory and will be chosen as soon as he confirms the settings dialog, so that he'll be able to edit it later.

Also, manual editing of the line-edit has effect (although most users may not use it):

 * If the user types a nonexistent file path inside the line-edit and confirms the settings dialog, the file will be created with the contents that are shown in the text view.
 * If the user types an existing, readable file path inside the line-edit, it'll be loaded when the line-edit loses focus — exactly as if the file was opened by pressing the "Find..." button.