### PR TITLE
Fixed a minor problem in full-screening in drop-down mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -762,9 +762,18 @@ void MainWindow::showHide()
     }
 
     if (isVisible())
+    {
         hide();
+    }
     else
     {
+        // The checked state of the fullscreen action should be reset; otherwise, its shortcut
+        // might need to be pressed twice later to make the window fullscreen. We don't consult
+        // "isFullScreen()" because it will return "false" if the window has been deactivated.
+        if (auto a = actions.value(QLatin1String(FULLSCREEN)))
+        {
+            a->setChecked(false);
+        }
         realign();
         show();
         activateWindow();


### PR DESCRIPTION
This small patch fixes the following issue in the drop-down mode:

 1. The window became fullscreen on pressing the fullscreen shortcut, as it should.
 2. After that, the window disappeared on pressing the drop-down shortcut, as it should.
 3. The window appeared with the correct size on pressing the drop-down shortcut again, as it should.

Then, the window wouldn't become fullscreen unless you pressed the fullscreen shortcut twice.

Closes https://github.com/lxqt/qterminal/issues/921