### PR TITLE
Fixed focus change on showing/hiding bookmarks dock

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -582,10 +582,6 @@ void MainWindow::showFullscreen(bool fullscreen)
 void MainWindow::toggleBookmarks()
 {
     m_bookmarksDock->toggleViewAction()->trigger();
-    if (m_bookmarksDock->isVisible())
-    {
-        m_bookmarksDock->widget()->setFocus();
-    }
 }
 
 
@@ -852,6 +848,10 @@ void MainWindow::newTerminalWindow()
 
 void MainWindow::bookmarksWidget_callCommand(const QString& cmd)
 {
+    if (m_bookmarksDock->isFloating())
+    {
+        activateWindow();
+    }
     consoleTabulator->terminalHolder()->currentTerminal()->impl()->sendText(cmd);
     consoleTabulator->terminalHolder()->currentTerminal()->setFocus();
 }
@@ -859,6 +859,18 @@ void MainWindow::bookmarksWidget_callCommand(const QString& cmd)
 void MainWindow::bookmarksDock_visibilityChanged(bool visible)
 {
     Properties::Instance()->bookmarksVisible = visible;
+    if (visible)
+    {
+        if (m_bookmarksDock->isFloating())
+        {
+            m_bookmarksDock->activateWindow();
+        }
+        m_bookmarksDock->widget()->setFocus();
+    }
+    else
+    { // this is especially needed in the drop-down mode
+        consoleTabulator->terminalHolder()->currentTerminal()->setFocus();
+    }
 }
 
 void MainWindow::addNewTab(TerminalConfig cfg)


### PR DESCRIPTION
Previously,

 * The focus didn't return to the drop-down terminal on hiding the bookmarks dock.
 * The detached dock wasn't activated when it was shown by using the shortcut (in contrast to detaching with mouse).
 * The main window wasn't activated after triggering a bookmark from a detached dock.

Fixes https://github.com/lxqt/qterminal/issues/928