### PR TITLE
Fixed updating of shortcuts on tab switching/removal/creation

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -871,7 +871,7 @@ void MainWindow::addNewTab(TerminalConfig cfg)
         consoleTabulator->preset2Horizontal();
     else
         consoleTabulator->addNewTab(cfg);
-    updateDisabledActions();
+    // disabled actions are updated by TabWidget::onCurrentChanged()
 }
 
 void MainWindow::onCurrentTitleChanged(int index)

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -60,7 +60,7 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
     connect(this, &TabWidget::tabRenameRequested, this, &TabWidget::renameSession);
     connect(this, &TabWidget::tabTitleColorChangeRequested, this, &TabWidget::setTitleColor);
     connect(mSwitcher.data(), &TabSwitcher::activateTab, this, &TabWidget::switchTab);
-    connect(this, &TabWidget::currentChanged, this, &TabWidget::saveCurrentChanged);
+    connect(this, &TabWidget::currentChanged, this, &TabWidget::onCurrentChanged);
 }
 
 TabWidget::~TabWidget()
@@ -344,7 +344,6 @@ void TabWidget::removeTab(int index)
 void TabWidget::switchTab(int index)
 {
     setCurrentIndex(index);
-    findParent<MainWindow>(this)->updateDisabledActions();
 }
 
 void TabWidget::onAction()
@@ -354,8 +353,11 @@ void TabWidget::onAction()
     switchTab(action->property("tab").toInt() - 1);
 }
 
-void TabWidget::saveCurrentChanged(int index)
+void TabWidget::onCurrentChanged(int index)
 {
+    // update disabled actions
+    findParent<MainWindow>(this)->updateDisabledActions();
+    // also, update hstory
     auto* w = widget(index);
     mHistory.removeAll(w);
     mHistory.prepend(w);

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -54,7 +54,7 @@ public slots:
     void removeTab(int);
     void switchTab(int);
     void onAction();
-    void saveCurrentChanged(int);
+    void onCurrentChanged(int);
     void removeCurrentTab();
     int switchToRight();
     int switchToLeft();


### PR DESCRIPTION
It's enough to update shortcuts on tab switching; tab removal and creation are automatically covered.

This PR supersedes and completes https://github.com/lxqt/qterminal/pull/666, which didn't cover problems in tab switching like the following:

 1. Split terminal.
 2. Open a new tab by using shortcut.
 3. Switch to the new tab and back to the previous one by clicking on tabs.

Then, before the current patch, shortcuts for sub-terminal switching didn't work until the Actions menu-bar item was shown.