### PR TITLE
Don't use a hidden `QWidget` as the parent of actions

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -150,8 +150,7 @@ void MainWindow::rebuildActions()
 {
     // Delete all setting-related QObjects
     delete settingOwner;
-    settingOwner = new QWidget(this);
-    settingOwner->setGeometry(0,0,0,0);
+    settingOwner = new QObject(this);
 
     // Then create them again
     setup_FileMenu_Actions();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -60,7 +60,7 @@ private:
 
     // A parent object for QObjects that are created dynamically based on settings
     // Used to simplify the setting cleanup on reconfiguration: deleting settingOwner frees all related QObjects
-    QWidget *settingOwner;
+    QObject *settingOwner;
 
     QMenu *presetsMenu;
     TerminalConfig m_config;


### PR DESCRIPTION
A hidden `QWidget` isn't a good choice as the parent of actions and may cause unpredictable problems. `QObject` should be used instead of it.

Closes https://github.com/lxqt/qterminal/issues/932, for now.