### PR TITLE
Autopopulate the rename text box

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -201,7 +201,7 @@ void TabWidget::renameSession(int index)
     bool ok = false;
     QString text = QInputDialog::getText(this, tr("Tab name"),
                                         tr("New tab name:"), QLineEdit::Normal,
-                                        QString(), &ok);
+                                        tabBar()->tabText(index), &ok);
     if(ok && !text.isEmpty())
     {
         setTabIcon(index, QIcon{});


### PR DESCRIPTION
QTerminal doesn't automatically autopopulate the text box with the existing name:
![image](https://user-images.githubusercontent.com/3689821/169907911-44691430-e04b-4adb-b7fd-cd18c4ede8b5.png)

This change fixes that, so it's easier to fix typos:

![image](https://user-images.githubusercontent.com/3689821/169907994-589bb261-af41-448d-a2bd-fe798cfcbc92.png)
