### PR TITLE
Fixed command parsing with `-e` option

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,3 +7,4 @@ pacman -S --noconfirm --needed git cmake lxqt-build-tools-git qt5-tools qtermwid
 
 cmake -B build -S .
 make -C build
+ARGS="-V" make -C build test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(GNUInstallDirs)
 set(QTERMINAL_VERSION "1.1.0")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
+option(BUILD_TESTS "Builds tests" ON)
 
 if(APPLE)
     option(APPLEBUNDLE "Build as qterminal.app bundle" ON)
@@ -35,6 +36,10 @@ if(UNIX)
 endif()
 find_package(QTermWidget5 ${QTERMWIDGET_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
+
+if (BUILD_TESTS)
+    find_package(Qt5 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Test)
+endif()
 
 include(LXQtPreventInSourceBuilds)
 include(LXQtTranslateTs)
@@ -75,6 +80,7 @@ set(QTERM_SRC
     src/fontdialog.cpp
     src/dbusaddressable.cpp
     src/tab-switcher.cpp
+    src/qterminalutils.cpp
 )
 
 set(QTERM_MOC_SRC
@@ -264,4 +270,9 @@ else()
     add_custom_command(TARGET ${EXE_NAME} POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/${EXE_NAME}.app/Contents/Resources/empty.lproj"
         COMMENT "Creating Resources/empty.lproj")
+endif()
+
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
 endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 
 #include "mainwindow.h"
 #include "qterminalapp.h"
+#include "qterminalutils.h"
 #include "terminalconfig.h"
 
 #define out
@@ -70,49 +71,6 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
 {
     printf("%s\n", QTERMINAL_VERSION);
     exit(code);
-}
-
-QStringList parse_command(const QString& str)
-{
-    const QRegularExpression separator(QString::fromLatin1(R"('|(?<!\\)(\\{2})*(\s|")|\z)"));
-    const QRegularExpression doubleQuote(QString::fromLatin1(R"((?<!\\)(\\{2})*")"));
-    const QRegularExpression escapedSpace(QString::fromLatin1(R"(\\(\\{2})*\s)"));
-    const QRegularExpression singleQuote(QStringLiteral("'"));
-
-    QStringList list;
-    QRegularExpressionMatch match;
-    int index = 0;
-    int nextIndex;
-    while((nextIndex = str.indexOf(separator, index, &match)) != -1)
-    {
-        if (nextIndex > index)
-        {
-            list << str.mid(index, nextIndex - index).replace(escapedSpace, QStringLiteral(" "));
-        }
-        if (match.capturedLength() == 0)
-        { // end of string ("\z") is matched
-            break;
-        }
-        index = nextIndex + match.capturedLength();
-        auto c = str.at(index - 1); // last matched character
-        if (!c.isSpace())
-        { // a single quote or an unescaped double quote is matched
-            nextIndex = str.indexOf(c == QLatin1Char('\'') ? singleQuote : doubleQuote, index, &match);
-            if (nextIndex == -1)
-            { // the quote is not closed
-                break;
-            }
-            else
-            {
-                if (nextIndex > index)
-                {
-                    list << str.mid(index, nextIndex - index).replace(escapedSpace, QStringLiteral(" "));
-                }
-                index = nextIndex + match.capturedLength();
-            }
-        }
-    }
-    return list;
 }
 
 void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode)

--- a/src/properties.h
+++ b/src/properties.h
@@ -50,7 +50,7 @@ class Properties
         QPoint mainWindowPosition;
         QByteArray mainWindowState;
         //ShortcutMap shortcuts;
-        QString shell;
+        QStringList shell;
         QFont font;
         QString colorScheme;
         QString guiStyle;

--- a/src/qterminalutils.cpp
+++ b/src/qterminalutils.cpp
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *   Copyright (C) 2022 by LXQt team                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#include <QRegularExpression>
+
+#include "qterminalutils.h"
+
+QStringList parse_command(const QString& str)
+{
+    const QRegularExpression separator(QString::fromLatin1(R"('|(?<!\\)(\\{2})*(\s|")|\z)"));
+    const QRegularExpression doubleQuote(QString::fromLatin1(R"((?<!\\)(\\{2})*")"));
+    const QRegularExpression escapedSpace(QString::fromLatin1(R"(\\(\\{2})*\s)"));
+    const QRegularExpression singleQuote(QStringLiteral("'"));
+
+    QStringList list;
+    QRegularExpressionMatch match;
+    int index = 0;
+    int nextIndex;
+    while((nextIndex = str.indexOf(separator, index, &match)) != -1)
+    {
+        if (nextIndex > index)
+        {
+            list << str.mid(index, nextIndex - index).replace(escapedSpace, QStringLiteral(" "));
+        }
+        if (match.capturedLength() == 0)
+        { // end of string ("\z") is matched
+            break;
+        }
+        index = nextIndex + match.capturedLength();
+        auto c = str.at(index - 1); // last matched character
+        if (!c.isSpace())
+        { // a single quote or an unescaped double quote is matched
+            nextIndex = str.indexOf(c == QLatin1Char('\'') ? singleQuote : doubleQuote, index, &match);
+            if (nextIndex == -1)
+            { // the quote is not closed
+                break;
+            }
+            else
+            {
+                if (nextIndex > index)
+                {
+                    list << str.mid(index, nextIndex - index).replace(escapedSpace, QStringLiteral(" "));
+                }
+                index = nextIndex + match.capturedLength();
+            }
+        }
+    }
+    return list;
+}
+

--- a/src/qterminalutils.h
+++ b/src/qterminalutils.h
@@ -1,0 +1,26 @@
+/***************************************************************************
+ *   Copyright (C) 2022 by LXQt team                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifndef QTERMINALUTILS_H
+#define QTERMINALUTILS_H
+
+#include <QString>
+#include <QStringList>
+
+QStringList parse_command(const QString& str);
+
+#endif

--- a/src/terminalconfig.h
+++ b/src/terminalconfig.h
@@ -11,15 +11,15 @@ class TermWidget;
 class TerminalConfig
 {
     public:
-        TerminalConfig(const QString & wdir, const QString & shell);
+        TerminalConfig(const QString & wdir, const QStringList & shell);
         TerminalConfig(const TerminalConfig &cfg);
         TerminalConfig();
 
         QString getWorkingDirectory();
-        QString getShell();
+        QStringList getShell();
 
         void setWorkingDirectory(const QString &val);
-        void setShell(const QString &val);
+        void setShell(const QStringList &val);
         void provideCurrentDirectory(const QString &val);
 
         #ifdef HAVE_QDBUS
@@ -29,10 +29,10 @@ class TerminalConfig
 
 
     private:
-    	// True when 
+    	// True when
     	QString m_currentDirectory;
     	QString m_workingDirectory;
-        QString m_shell;
+        QStringList m_shell;
 };
 
 #endif

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -55,16 +55,13 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
 
     setWorkingDirectory(cfg.getWorkingDirectory());
 
-    QString shell = cfg.getShell();
+    QStringList shell = cfg.getShell();
     if (!shell.isEmpty())
     {
-        //qDebug() << "Shell program:" << shell;
-        QStringList parts = shell.split(QRegExp(QStringLiteral("\\s+")), Qt::SkipEmptyParts);
-        //qDebug() << parts;
-        setShellProgram(parts.at(0));
-        parts.removeAt(0);
-        if (parts.count())
-            setArgs(parts);
+        setShellProgram(shell.at(0));
+        shell.removeAt(0);
+        if (!shell.isEmpty())
+            setArgs(shell);
     }
 
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,7 @@
+qt5_wrap_cpp(QTERM_TEST_MOC qterminal_test.h)
+add_executable(qterminal_test
+    qterminal_test.cpp
+    ${CMAKE_SOURCE_DIR}/src/qterminalutils.cpp
+    ${QTERM_TEST_MOC})
+target_link_libraries(qterminal_test Qt5::Test)
+add_test(NAME qterminal_test COMMAND qterminal_test)

--- a/test/qterminal_test.cpp
+++ b/test/qterminal_test.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *   Copyright (C) 2022 by LXQt team                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#include "qterminal_test.h"
+
+#include "qterminalutils.h"
+
+#include <QtTest>
+
+// handy shortcut copied from liblxqt
+#ifndef QL1S
+#define QL1S(x) QLatin1String(x)
+#endif
+
+void QTerminalTest::testParseCommand()
+{
+    /* Common usage */
+    // qterminal -e 'fpad -s "PATH/ha ha"'
+    // qterminal -e "fpad -s \"PATH/ha ha\"" # \" is decoded as " by the shell
+    QCOMPARE(parse_command(QL1S(R"(fpad -s "PATH/ha ha")")),
+             QStringList() << QL1S("fpad") << QL1S("-s") << QL1S("PATH/ha ha"));
+    // qterminal -e "fpad -s 'PATH/ha ha'"
+    QCOMPARE(parse_command(QL1S(R"(fpad -s 'PATH/ha ha')")),
+             QStringList() << QL1S("fpad") << QL1S("-s") << QL1S("PATH/ha ha"));
+    // qterminal -e 'fpad -s PATH/ha\ ha'
+    // qterminal -e "fpad -s PATH/ha\ ha"
+    QCOMPARE(parse_command(QL1S(R"(fpad -s PATH/ha\ ha)")),
+             QStringList() << QL1S("fpad") << QL1S("-s") << QL1S("PATH/ha ha"));
+
+    /* Uncommon usage */
+    // qterminal -e 'fpad -s \"PATH/ha ha\"'
+    QCOMPARE(parse_command(QL1S(R"(fpad -s \"PATH/ha ha\")")),
+             QStringList() << QL1S("fpad") << QL1S("-s") << QL1S("\\\"PATH/ha") << QL1S("ha\\\""));
+    // qterminal -e 'fpad -s "PATH/ha\ ha"'
+    QCOMPARE(parse_command(QL1S(R"(fpad -s "PATH/ha\ ha")")),
+             QStringList() << QL1S("fpad") << QL1S("-s") << QL1S("PATH/ha ha"));
+}
+
+QTEST_MAIN(QTerminalTest)

--- a/test/qterminal_test.h
+++ b/test/qterminal_test.h
@@ -1,0 +1,32 @@
+/***************************************************************************
+ *   Copyright (C) 2022 by LXQt team                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifndef QTERMINAL_TEST_H
+#define QTERMINAL_TEST_H
+
+#include <QObject>
+
+class QTerminalTest : public QObject
+{
+    Q_OBJECT
+
+    // Each private slot is a test function
+private Q_SLOTS:
+    void testParseCommand();
+};
+
+#endif


### PR DESCRIPTION
By using `QStringList` instead of `QString`.

Fixes https://github.com/lxqt/qterminal/issues/335 and fixes https://github.com/lxqt/qterminal/issues/665