### PR TITLE
adding yet another knob fixname to the bookmarks.xml

### DIFF
--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -33,9 +33,10 @@ public:
         Command = 2
     };
 
-    AbstractBookmarkItem(ItemType type, AbstractBookmarkItem* parent = nullptr)
+    AbstractBookmarkItem(ItemType type, AbstractBookmarkItem* parent = nullptr, int newtab = 0)
         : m_type(type),
-          m_parent(parent)
+          m_parent(parent),
+          m_newtab(newtab)
     {
     }
     virtual ~AbstractBookmarkItem()
@@ -46,6 +47,7 @@ public:
     ItemType type() { return m_type; }
     QString value() { return m_value; }
     QString display() { return m_display; }
+    int newtab() { return m_newtab; }
 
     void addChild(AbstractBookmarkItem* item) { m_children << item; }
     int childCount() { return m_children.count(); }
@@ -67,6 +69,7 @@ protected:
     QList<AbstractBookmarkItem*> m_children;
     QString m_value;
     QString m_display;
+    int m_newtab;
 };
 
 class BookmarkRootItem : public AbstractBookmarkItem
@@ -76,17 +79,19 @@ public:
         : AbstractBookmarkItem(AbstractBookmarkItem::Root)
     {
         m_value = m_display = QStringLiteral("root");
+        m_newtab = 0;
     }
 };
 
 class BookmarkCommandItem : public AbstractBookmarkItem
 {
 public:
-    BookmarkCommandItem(const QString &name, const QString &command, AbstractBookmarkItem *parent)
+    BookmarkCommandItem(const QString &name, const QString &command, int newtab, AbstractBookmarkItem *parent)
         : AbstractBookmarkItem(AbstractBookmarkItem::Command, parent)
     {
         m_value = command;
         m_display = name;
+        m_newtab = newtab;
     }
 };
 
@@ -148,8 +153,9 @@ public:
                 {
                     QString name = xml.attributes().value(QLatin1String("name")).toString();
                     QString cmd = xml.attributes().value(QLatin1String("value")).toString();
+                    int newtab = xml.attributes().value(QLatin1String("newtab")).toInt();
 
-                    BookmarkCommandItem *i = new BookmarkCommandItem(name, cmd, parent);
+                    BookmarkCommandItem *i = new BookmarkCommandItem(name, cmd, newtab, parent);
                     parent->addChild(i);
                 }
                 break;
@@ -362,7 +368,7 @@ void BookmarksWidget::handleCommand(const QModelIndex& index)
     if (!item || item->type() != AbstractBookmarkItem::Command)
         return;
 
-    emit callCommand(item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
+    emit callCommand(item->newtab(), item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
 }
 
 void BookmarksWidget::filter(const QString& str)

--- a/src/bookmarkswidget.cpp
+++ b/src/bookmarkswidget.cpp
@@ -33,10 +33,11 @@ public:
         Command = 2
     };
 
-    AbstractBookmarkItem(ItemType type, AbstractBookmarkItem* parent = nullptr, int newtab = 0)
+    AbstractBookmarkItem(ItemType type, AbstractBookmarkItem* parent = nullptr, int newtab = 0, int fixname = 0)
         : m_type(type),
           m_parent(parent),
-          m_newtab(newtab)
+          m_newtab(newtab),
+          m_fixname(fixname)
     {
     }
     virtual ~AbstractBookmarkItem()
@@ -48,6 +49,7 @@ public:
     QString value() { return m_value; }
     QString display() { return m_display; }
     int newtab() { return m_newtab; }
+    int fixname() { return m_fixname; }
 
     void addChild(AbstractBookmarkItem* item) { m_children << item; }
     int childCount() { return m_children.count(); }
@@ -63,6 +65,8 @@ public:
         return 0;
     }
 
+    int m_visible;
+
 protected:
     ItemType m_type;
     AbstractBookmarkItem *m_parent;
@@ -70,6 +74,7 @@ protected:
     QString m_value;
     QString m_display;
     int m_newtab;
+    int m_fixname;
 };
 
 class BookmarkRootItem : public AbstractBookmarkItem
@@ -80,18 +85,20 @@ public:
     {
         m_value = m_display = QStringLiteral("root");
         m_newtab = 0;
+        m_fixname = 0;
     }
 };
 
 class BookmarkCommandItem : public AbstractBookmarkItem
 {
 public:
-    BookmarkCommandItem(const QString &name, const QString &command, int newtab, AbstractBookmarkItem *parent)
+    BookmarkCommandItem(const QString &name, const QString &command, int newtab, int fixname, AbstractBookmarkItem *parent)
         : AbstractBookmarkItem(AbstractBookmarkItem::Command, parent)
     {
         m_value = command;
         m_display = name;
         m_newtab = newtab;
+        m_fixname = fixname;
     }
 };
 
@@ -154,8 +161,9 @@ public:
                     QString name = xml.attributes().value(QLatin1String("name")).toString();
                     QString cmd = xml.attributes().value(QLatin1String("value")).toString();
                     int newtab = xml.attributes().value(QLatin1String("newtab")).toInt();
+                    int fixname = xml.attributes().value(QLatin1String("fixname")).toInt();
 
-                    BookmarkCommandItem *i = new BookmarkCommandItem(name, cmd, newtab, parent);
+                    BookmarkCommandItem *i = new BookmarkCommandItem(name, cmd, newtab, fixname, parent);
                     parent->addChild(i);
                 }
                 break;
@@ -368,13 +376,22 @@ void BookmarksWidget::handleCommand(const QModelIndex& index)
     if (!item || item->type() != AbstractBookmarkItem::Command)
         return;
 
-    emit callCommand(item->newtab(), item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
+    emit callCommand(item->newtab(), item->fixname(), item->display(), item->value() + QLatin1Char('\n')); // TODO/FIXME: decide how to handle EOL
 }
 
 void BookmarksWidget::filter(const QString& str)
 {
     treeView->clearSelection();
     const QModelIndexList list = m_model->allChildRows(QModelIndex());
+
+    // first mark everyone hidden
+    for (const auto& index : list)
+    {
+        AbstractBookmarkItem *item = static_cast<AbstractBookmarkItem*>(index.internalPointer());
+        item->m_visible = 0;
+    }
+
+    // now mark the matching ones visible
     for (const auto& index : list)
     {
         AbstractBookmarkItem *item = static_cast<AbstractBookmarkItem*>(index.internalPointer());
@@ -383,12 +400,36 @@ void BookmarksWidget::filter(const QString& str)
             if (item->value().contains(str, Qt::CaseInsensitive)
                 || item->display().contains(str, Qt::CaseInsensitive))
             {
-                treeView->setRowHidden(index.row(), index.parent(), false);
-            }
-            else
-            {
-                treeView->setRowHidden(index.row(), index.parent(), true);
+                item->m_visible = 1;
             }
         }
     }
+
+    // now who became visible, their parents, grandparents, grand-grandparents, etc, need to be marked too
+    for (const auto& index : list)
+    {
+        AbstractBookmarkItem *item = static_cast<AbstractBookmarkItem*>(index.internalPointer());
+        if (item->m_visible == 0)
+            continue;
+        for (;;)
+        {
+            item = item->parent();
+            if (item == nullptr)
+                break;
+            item->m_visible = 1;
+        }
+    }
+
+    // finally do update the view
+    for (const auto& index : list)
+    {
+        AbstractBookmarkItem *item = static_cast<AbstractBookmarkItem*>(index.internalPointer());
+        if (item->m_visible == 0)
+        {
+            treeView->setRowHidden(index.row(), index.parent(), true);
+        } else {
+            treeView->setRowHidden(index.row(), index.parent(), false);
+        }
+    }
+
 }

--- a/src/bookmarkswidget.h
+++ b/src/bookmarkswidget.h
@@ -36,7 +36,7 @@ public:
     void setup();
 
 signals:
-    void callCommand(const QString &cmd);
+    void callCommand(int newtab, const QString &cmd);
 
 private:
     BookmarksModel *m_model;

--- a/src/bookmarkswidget.h
+++ b/src/bookmarkswidget.h
@@ -36,7 +36,7 @@ public:
     void setup();
 
 signals:
-    void callCommand(int newtab, const QString &cmd);
+    void callCommand(int newtab, int fixname, const QString &name, const QString &cmd);
 
 private:
     BookmarksModel *m_model;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -853,11 +853,16 @@ void MainWindow::newTerminalWindow()
     w->show();
 }
 
-void MainWindow::bookmarksWidget_callCommand(int newtab, const QString& cmd)
+void MainWindow::bookmarksWidget_callCommand(int newtab, int fixname, const QString& name, const QString& cmd)
 {
     if (newtab != 0) {
         addNewTab(m_config);
     }
+
+    if (fixname != 0) {
+        consoleTabulator->setFixedName(consoleTabulator->currentIndex(), name);
+    }
+
     if (m_bookmarksDock->isFloating())
     {
         activateWindow();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -853,8 +853,11 @@ void MainWindow::newTerminalWindow()
     w->show();
 }
 
-void MainWindow::bookmarksWidget_callCommand(const QString& cmd)
+void MainWindow::bookmarksWidget_callCommand(int newtab, const QString& cmd)
 {
+    if (newtab != 0) {
+        addNewTab(m_config);
+    }
     if (m_bookmarksDock->isFloating())
     {
         activateWindow();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -114,7 +114,7 @@ private slots:
     void find();
 
     void newTerminalWindow();
-    void bookmarksWidget_callCommand(const QString&);
+    void bookmarksWidget_callCommand(int, const QString&);
     void bookmarksDock_visibilityChanged(bool visible);
 
     void addNewTab(TerminalConfig cfg = TerminalConfig());

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -114,7 +114,7 @@ private slots:
     void find();
 
     void newTerminalWindow();
-    void bookmarksWidget_callCommand(int, const QString&);
+    void bookmarksWidget_callCommand(int, int, const QString&, const QString&);
     void bookmarksDock_visibilityChanged(bool visible);
 
     void addNewTab(TerminalConfig cfg = TerminalConfig());

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -196,6 +196,16 @@ void TabWidget::onTermTitleChanged(const QString& title, const QString& icon)
     }
 }
 
+void TabWidget::setFixedName(int index, QString text)
+{
+printf("here%i\n",index);///
+    setTabIcon(index, QIcon{});
+    setTabText(index, text);
+    widget(index)->setProperty(TAB_CUSTOM_NAME_PROPERTY, true);
+    if (currentIndex() == index)
+        emit currentTitleChanged(index);
+}
+
 void TabWidget::renameSession(int index)
 {
     bool ok = false;
@@ -204,11 +214,7 @@ void TabWidget::renameSession(int index)
                                         QString(), &ok);
     if(ok && !text.isEmpty())
     {
-        setTabIcon(index, QIcon{});
-        setTabText(index, text);
-        widget(index)->setProperty(TAB_CUSTOM_NAME_PROPERTY, true);
-        if (currentIndex() == index)
-            emit currentTitleChanged(index);
+        setFixedName(index, text);
     }
 }
 

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -61,6 +61,7 @@ public slots:
     void removeFinished();
     void moveLeft();
     void moveRight();
+    void setFixedName(int, QString);
     void renameSession(int);
     void renameCurrentSession();
     void setTitleColor(int);


### PR DESCRIPTION
it's a new knob to the bookmarks.xml, if set, the tab title is fixed...
it's useful for the connection manager use case, with the newtab also set...
the one will have dedicated tabs, always visible with the familiar name...
it also helps in the cases the remote does not sent the ansi sequence to set the title