### PR TITLE
Specified the parent of main context menu for use on Wayland

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -137,7 +137,7 @@ void TermWidgetImpl::propertiesChanged()
 
 void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 {
-    QMenu menu;
+    QMenu menu(this);
     QMap<QString, QAction*> actions = findParent<MainWindow>(this)->leaseActions();
 
     QList<QAction*> extraActions = filterActions(pos);


### PR DESCRIPTION
On Wayland, a parentless context menu might pop up in an incorrect position and even have a window decoration if the window is inactive when right clicked.