### PR TITLE
Improve User Experience, change default values properties.cpp

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -132,7 +132,7 @@ void Properties::loadSettings()
     askOnExit = m_settings->value(QLatin1String("AskOnExit"), true).toBool();
     saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
     savePosOnExit = m_settings->value(QLatin1String("SavePosOnExit"), true).toBool();
-    useCWD = m_settings->value(QLatin1String("UseCWD"), false).toBool();
+    useCWD = m_settings->value(QLatin1String("UseCWD"), true).toBool();
     m_openNewTabRightToActiveTab = m_settings->value(QLatin1String("OpenNewTabRightToActiveTab"), false).toBool();
     term = m_settings->value(QLatin1String("Term"), QLatin1String("xterm-256color")).toString();
     handleHistoryCommand = m_settings->value(QLatin1String("HandleHistory")).toString();


### PR DESCRIPTION
* Change default useCWD value from false to true.

useCWD is the "Open new terminals in current working directory" option.

I think it improves the user experience, because it pissed me off, working in the terminal, to open a new tab, and have to move all the way to the current working folder, and do that for every new tab. That is the default behavior a user wants, to open new tabs in the current working directory.
