### PR TITLE
Typo fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -58,7 +58,7 @@ qterminal-0.16.0 / 2020-11-01
   * Use the default constructor of QFlags.
   * Dropped qmake .pro file.
   * Made the color scheme dirs comply with XDG Base Directory Specification.
-  * Added an optopn for openning the new tab to the right of the active tab.
+  * Added an optopn for opening the new tab to the right of the active tab.
   * Added virtual destructor to a base class.
   * Let QStandardPaths::locateAll() handle application name.
   * Put drop-down QTerminal on screen with cursor.
@@ -119,7 +119,7 @@ qterminal-0.14.0 / 2019-01-25
     - Refactor STR_VERSION -> QTERMINAL_VERSION
   * Improved cmake scripting
     - Set cmake_minimum_required to 3.1.0
-    - Removed locale compile definitons
+    - Removed locale compile definitions
   * Moved translations from lxqt-l10n back to qterminal
    - Removed obsolete translation fuctionality
    - Added translation promo in README.md
@@ -373,7 +373,7 @@ qterminal-0.5.0 / 2014-05-27
   * fixed #51 Shortcuts broken after menu hiding
   * fixed #50 Bookmarks panel always shows, even if the bookmarks are disabled
   * fixed #49 Only show monospace fonts in the font picker
-  * save bookmars widget visibility; fix crash in some config circumstances
+  * save bookmarks widget visibility; fix crash in some config circumstances
   * Include QApplication where needed. Fixes #47
   * removed un-needed file
   * changes required for new qtermwidget build/structure; includes fixed for qtermwidget Qt5 port
@@ -404,7 +404,7 @@ qterminal-0.5.0 / 2014-05-27
   * fixed main window ui file (manually edited probably) to work with designr again. Use "Preferences..." instead of "Configure QTerminal"
   * compile also italian translations
   * added italian translations
-  * get rid of contraproductive Ctrl-W to close a tab. Replaced that   wieht Ctrl-Shift-W. Use nano in qterminal and try to search. You   will see, what i mean ... * it takes a horizontal ruler to tile a terminal vertically and   vice versa * make border of active terminal a litte bit thinner 3px -> 2px
+  * get rid of contraproductive Ctrl-W to close a tab. Replaced that   wieht Ctrl-Shift-W. Use nano in qterminal and try to search. You   will see, what i mean ... * it takes a horizontal ruler to tile a terminal vertically and   vice versa * make border of active terminal a little bit thinner 3px -> 2px
   * Added new action: "Paste Selection". Fixes #21
   * Handle migration "Paste Selection"->"Paste Clipboard" in settings
   * Rename PASTE_SELECTION to PASTE_CLIPBOARD which is what it does
@@ -432,7 +432,7 @@ qterminal-0.5.0 / 2014-05-27
   * yakuake mode compile fix for X11
   * build on mac
   * Switch to Qxt global shortcut
-  * "make lupdate" implemented; do ot delete ts files on "make clean"; fix translator loading
+  * "make lupdate" implemented; do not delete ts files on "make clean"; fix translator loading
   * DropDown mode
   * allow translations
   * tabs to spaces

--- a/Doxyfile
+++ b/Doxyfile
@@ -279,7 +279,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
 # a logarithmic scale so increasing the size by one will roughly double the
@@ -1050,7 +1050,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are
 # not supported properly for IE 6.0, but are supported on all modern browsers.
 # Note that when changing this option you need to delete any form_*.png files

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -329,13 +329,13 @@ void MainWindow::setup_ActionsMenu_Actions()
 
     // TODO/FIXME: unimplemented for now
     act = new QAction(tr("&Save Session"), this);
-    // do not use sequences for this task - it collides with eg. mc shorcuts
+    // do not use sequences for this task - it collides with eg. mc shortcuts
     // and mainly - it's not used too often
     //act->setShortcut(QKeySequence::Save);
     connect(act, SIGNAL(triggered()), consoleTabulator, SLOT(saveSession()));
 
     act = new QAction(tr("&Load Session"), this);
-    // do not use sequences for this task - it collides with eg. mc shorcuts
+    // do not use sequences for this task - it collides with eg. mc shortcuts
     // and mainly - it's not used too often
     //act->setShortcut(QKeySequence::Open);
     connect(act, SIGNAL(triggered()), consoleTabulator, SLOT(loadSession()));
@@ -734,7 +734,7 @@ void MainWindow::realign()
         const QRect desktop = appScreen->availableGeometry();
         QRect g = QRect(desktop.x(),
                         desktop.y(),
-                        desktop.width()  * Properties::Instance()->dropWidht  / 100,
+                        desktop.width()  * Properties::Instance()->dropWidth  / 100,
                         desktop.height() * Properties::Instance()->dropHeight / 100);
         g.moveCenter(desktop.center());
         // do not use 0 here - we need to calculate with potential panel on top

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -149,7 +149,7 @@ void Properties::loadSettings()
     dropShortCut = QKeySequence(m_settings->value(QLatin1String("ShortCut"), QLatin1String("F12")).toString());
     dropKeepOpen = m_settings->value(QLatin1String("KeepOpen"), false).toBool();
     dropShowOnStart = m_settings->value(QLatin1String("ShowOnStart"), true).toBool();
-    dropWidht = m_settings->value(QLatin1String("Width"), 70).toInt();
+    dropWidth = m_settings->value(QLatin1String("Width"), 70).toInt();
     dropHeight = m_settings->value(QLatin1String("Height"), 45).toInt();
     m_settings->endGroup();
 
@@ -258,7 +258,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("ShortCut"), dropShortCut.toString());
     m_settings->setValue(QLatin1String("KeepOpen"), dropKeepOpen);
     m_settings->setValue(QLatin1String("ShowOnStart"), dropShowOnStart);
-    m_settings->setValue(QLatin1String("Width"), dropWidht);
+    m_settings->setValue(QLatin1String("Width"), dropWidth);
     m_settings->setValue(QLatin1String("Height"), dropHeight);
     m_settings->endGroup();
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -111,7 +111,7 @@ class Properties
         QKeySequence dropShortCut;
         bool dropKeepOpen;
         bool dropShowOnStart;
-        int dropWidht;
+        int dropWidth;
         int dropHeight;
 
         bool changeWindowTitle;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -243,7 +243,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropHeightSpinBox->setMaximum(100);
     dropWidthSpinBox->setMaximum(100);
     dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
-    dropWidthSpinBox->setValue(Properties::Instance()->dropWidht);
+    dropWidthSpinBox->setValue(Properties::Instance()->dropWidth);
 
     dropShortCutEdit = new KeySequenceEdit();
     dropShortCutFormLayout->setWidget(0, QFormLayout::FieldRole, dropShortCutEdit);
@@ -364,7 +364,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->dropShowOnStart = dropShowOnStartCheckBox->isChecked();
     Properties::Instance()->dropKeepOpen = dropKeepOpenCheckBox->isChecked();
     Properties::Instance()->dropHeight = dropHeightSpinBox->value();
-    Properties::Instance()->dropWidht = dropWidthSpinBox->value();
+    Properties::Instance()->dropWidth = dropWidthSpinBox->value();
     Properties::Instance()->dropShortCut = dropShortCutEdit->keySequence();
 
     Properties::Instance()->useBookmarks = useBookmarksCheckBox->isChecked();

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -364,7 +364,7 @@ void TabWidget::onCurrentChanged(int index)
 {
     // update disabled actions
     findParent<MainWindow>(this)->updateDisabledActions();
-    // also, update hstory
+    // also, update history
     auto* w = widget(index);
     mHistory.removeAll(w);
     mHistory.prepend(w);
@@ -377,7 +377,7 @@ const QList<QWidget*>& TabWidget::history() const
 
 void TabWidget::removeCurrentTab()
 {
-    // question disabled due user requests. Yes I agree it was anoying.
+    // question disabled due user requests. Yes I agree it was annoying.
 //    if (QMessageBox::question(this,
 //                    tr("Close current session"),
 //                    tr("Are you sure you want to close current sesstion?"),

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -37,7 +37,7 @@ typedef enum NavigationDirection {
 
 /*! \brief TermWidget group/session manager.
 
-This widget (one per TabWidget tab) is a "proxy" widget beetween TabWidget and
+This widget (one per TabWidget tab) is a "proxy" widget between TabWidget and
 unspecified count of TermWidgets. Basically it should look like a single TermWidget
 for TabWidget - with its signals and slots.
 


### PR DESCRIPTION
Comments/text typos:
- CHANGELOG
- Doxyfile
- src/mainwindow.cpp
- src/tabwidget.cpp
- src/termwidgetholder.h

Identifier typo: (`Properties::dropWidht`)
- src/mainwindow.cpp
- src/properties.cpp
- src/properties.h
- src/propertiesdialog.cpp
