### PR TITLE
Use qWarning().noquote() on warnings with escaped characters

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -187,7 +187,7 @@ void MainWindow::setDropShortcut(const QKeySequence& dropShortCut)
     if (m_dropShortcut.shortcut() != dropShortCut)
     {
         m_dropShortcut.setShortcut(dropShortCut);
-        qWarning() << tr("Press \"%1\" to see the terminal.").arg(dropShortCut.toString());
+        qWarning().noquote() << tr("Press \"%1\" to see the terminal.").arg(dropShortCut.toString());
     }
 }
 


### PR DESCRIPTION
Since Qt 5.4 `qWarning() <<` prints escaped characters with the `\`. Using `qWarning().noquote()` prints them as intended.