### PR TITLE
Fixed a crash in context menu

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -137,8 +137,13 @@ void TermWidgetImpl::propertiesChanged()
 
 void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
 {
-    QMenu menu(this);
-    QMap<QString, QAction*> actions = findParent<MainWindow>(this)->leaseActions();
+    auto mainWindow = findParent<MainWindow>(this);
+    if (mainWindow == nullptr)
+    {
+        return;
+    }
+    QMenu menu(mainWindow);
+    QMap<QString, QAction*> actions = mainWindow->leaseActions();
 
     QList<QAction*> extraActions = filterActions(pos);
     for (auto& action : extraActions)


### PR DESCRIPTION
The context menu needs a parent for being positioned correctly under Wayland (→ https://github.com/lxqt/qterminal/commit/27f2e7ce0a2a1cd476fb4abe8b97888fe22f0e4f). But the parent shouldn't be `TermWidgetImpl` because, otherwise, the app will crash on clicking the action `SUB_COLLAPSE` (which deletes the parent before the menu is closed).

The patch prevents the crash by choosing the main window as the parent.