### PR TITLE
Reorder propertiesdialog.ui XML to correct tab order

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -14,16 +14,6 @@
    <string>Terminal settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="1" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QListWidget" name="listWidget">
      <item>
@@ -111,27 +101,11 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>406</width>
-            <height>800</height>
+            <width>440</width>
+            <height>925</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <item row="20" column="1">
-            <widget class="QSpinBox" name="appTransparencyBox">
-             <property name="suffix">
-              <string> %</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>99</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="0" rowspan="2" colspan="2">
             <widget class="QWidget" name="fontWidget" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -193,49 +167,18 @@
              </layout>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
-            <widget class="QCheckBox" name="showMenuCheckBox">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_5">
              <property name="text">
-              <string>Show the menu bar</string>
+              <string>Color scheme</string>
+             </property>
+             <property name="buddy">
+              <cstring>colorSchemaCombo</cstring>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
             <widget class="QComboBox" name="colorSchemaCombo"/>
-           </item>
-           <item row="24" column="0">
-            <widget class="QLabel" name="label_9">
-             <property name="text">
-              <string>Start with preset:</string>
-             </property>
-             <property name="buddy">
-              <cstring>terminalPresetComboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="24" column="1">
-            <widget class="QComboBox" name="terminalPresetComboBox">
-             <item>
-              <property name="text">
-               <string>None (single terminal)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals horizontally</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals vertically</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4 terminals</string>
-              </property>
-             </item>
-            </widget>
            </item>
            <item row="3" column="0">
             <widget class="QLabel" name="label_6">
@@ -247,13 +190,79 @@
              </property>
             </widget>
            </item>
-           <item row="25" column="0">
-            <widget class="QLabel" name="label_15">
+           <item row="3" column="1">
+            <widget class="QComboBox" name="styleComboBox"/>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_7">
              <property name="text">
-              <string>Terminal margin</string>
+              <string>Scrollbar position</string>
              </property>
              <property name="buddy">
-              <cstring>terminalMarginSpinBox</cstring>
+              <cstring>scrollBarPos_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Tabs position</string>
+             </property>
+             <property name="buddy">
+              <cstring>tabsPos_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QComboBox" name="tabsPos_comboBox"/>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>Cursor shape</string>
+             </property>
+             <property name="buddy">
+              <cstring>keybCursorShape_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
+           </item>
+           <item row="7" column="0" colspan="2">
+            <widget class="QCheckBox" name="boldIntenseCheckBox">
+             <property name="toolTip">
+              <string>Toggles usage of bold font face for rendering intense colors</string>
+             </property>
+             <property name="text">
+              <string>Use bold font face for intense colors</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0" colspan="2">
+            <widget class="QCheckBox" name="menuAccelCheckBox">
+             <property name="toolTip">
+              <string>Accelerators are activated by Alt and can interfere with the terminal.</string>
+             </property>
+             <property name="text">
+              <string>No menu bar accelerator</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0" colspan="2">
+            <widget class="QCheckBox" name="showMenuCheckBox">
+             <property name="text">
+              <string>Show the menu bar</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0" colspan="2">
+            <widget class="QCheckBox" name="borderlessCheckBox">
+             <property name="text">
+              <string>&amp;Hide Window Borders</string>
              </property>
             </widget>
            </item>
@@ -264,23 +273,137 @@
              </property>
             </widget>
            </item>
+           <item row="12" column="0">
+            <widget class="QCheckBox" name="fixedTabWidthCheckBox">
+             <property name="text">
+              <string>Fixed tab width:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="1">
+            <widget class="QSpinBox" name="fixedTabWidthSpinBox">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="suffix">
+              <string>px</string>
+             </property>
+             <property name="maximum">
+              <number>1000</number>
+             </property>
+            </widget>
+           </item>
+           <item row="13" column="0" colspan="2">
+            <widget class="QCheckBox" name="highlightCurrentCheckBox">
+             <property name="text">
+              <string>Show a border around the current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="14" column="0" colspan="2">
+            <widget class="QCheckBox" name="closeTabButtonCheckBox">
+             <property name="text">
+              <string>Show close button on each tab</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="0" colspan="2">
+            <widget class="QCheckBox" name="changeWindowTitleCheckBox">
+             <property name="text">
+              <string>Change window title based on current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0" colspan="2">
+            <widget class="QCheckBox" name="changeWindowIconCheckBox">
+             <property name="text">
+              <string>Change window icon based on current terminal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="17" column="0" colspan="2">
+            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
+             <property name="text">
+              <string>Show terminal size on resize</string>
+             </property>
+            </widget>
+           </item>
+           <item row="18" column="0" colspan="2">
+            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
+             <property name="text">
+              <string>Enable bi-directional text support</string>
+             </property>
+            </widget>
+           </item>
+           <item row="19" column="0" colspan="2">
+            <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
+             <property name="toolTip">
+              <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
+             </property>
+             <property name="text">
+              <string>Use box drawing characters contained in the font</string>
+             </property>
+            </widget>
+           </item>
+           <item row="20" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Application transparency</string>
+             </property>
+             <property name="buddy">
+              <cstring>appTransparencyBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="20" column="1">
+            <widget class="QSpinBox" name="appTransparencyBox">
+             <property name="suffix">
+              <string> %</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>99</number>
+             </property>
+             <property name="value">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Terminal transparency</string>
+             </property>
+             <property name="buddy">
+              <cstring>termTransparencyBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="21" column="1">
+            <widget class="QSpinBox" name="termTransparencyBox">
+             <property name="suffix">
+              <string> %</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
            <item row="22" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Color scheme</string>
-             </property>
-             <property name="buddy">
-              <cstring>colorSchemaCombo</cstring>
              </property>
             </widget>
            </item>
@@ -334,18 +457,56 @@
              </item>
             </widget>
            </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_12">
+           <item row="24" column="0">
+            <widget class="QLabel" name="label_9">
              <property name="text">
-              <string>Cursor shape</string>
+              <string>Start with preset:</string>
              </property>
              <property name="buddy">
-              <cstring>keybCursorShape_comboBox</cstring>
+              <cstring>terminalPresetComboBox</cstring>
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="tabsPos_comboBox"/>
+           <item row="24" column="1">
+            <widget class="QComboBox" name="terminalPresetComboBox">
+             <item>
+              <property name="text">
+               <string>None (single terminal)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals horizontally</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals vertically</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>4 terminals</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="25" column="0">
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Terminal margin</string>
+             </property>
+             <property name="buddy">
+              <cstring>terminalMarginSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="25" column="1">
+            <widget class="QSpinBox" name="terminalMarginSpinBox">
+             <property name="suffix">
+              <string>px</string>
+             </property>
+            </widget>
            </item>
            <item row="26" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
@@ -359,177 +520,6 @@
               </size>
              </property>
             </spacer>
-           </item>
-           <item row="14" column="0" colspan="2">
-            <widget class="QCheckBox" name="closeTabButtonCheckBox">
-             <property name="text">
-              <string>Show close button on each tab</string>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Scrollbar position</string>
-             </property>
-             <property name="buddy">
-              <cstring>scrollBarPos_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="21" column="0">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Terminal transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>termTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
-           </item>
-           <item row="20" column="0">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Application transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>appTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="13" column="0" colspan="2">
-            <widget class="QCheckBox" name="highlightCurrentCheckBox">
-             <property name="text">
-              <string>Show a border around the current terminal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="25" column="1">
-            <widget class="QSpinBox" name="terminalMarginSpinBox">
-             <property name="suffix">
-              <string>px</string>
-             </property>
-            </widget>
-           </item>
-           <item row="18" column="0" colspan="2">
-            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
-             <property name="text">
-              <string>Enable bi-directional text support</string>
-             </property>
-            </widget>
-           </item>
-           <item row="21" column="1">
-            <widget class="QSpinBox" name="termTransparencyBox">
-             <property name="suffix">
-              <string> %</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="1">
-            <widget class="QSpinBox" name="fixedTabWidthSpinBox">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="suffix">
-              <string>px</string>
-             </property>
-             <property name="maximum">
-              <number>1000</number>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_8">
-             <property name="text">
-              <string>Tabs position</string>
-             </property>
-             <property name="buddy">
-              <cstring>tabsPos_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="15" column="0" colspan="2">
-            <widget class="QCheckBox" name="changeWindowTitleCheckBox">
-             <property name="text">
-              <string>Change window title based on current terminal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="0">
-            <widget class="QCheckBox" name="fixedTabWidthCheckBox">
-             <property name="text">
-              <string>Fixed tab width:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="styleComboBox"/>
-           </item>
-           <item row="16" column="0" colspan="2">
-            <widget class="QCheckBox" name="changeWindowIconCheckBox">
-             <property name="text">
-              <string>Change window icon based on current terminal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="17" column="0" colspan="2">
-            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
-             <property name="text">
-              <string>Show terminal size on resize</string>
-             </property>
-            </widget>
-           </item>
-           <item row="19" column="0" colspan="2">
-            <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
-             <property name="toolTip">
-              <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
-             </property>
-             <property name="text">
-              <string>Use box drawing characters contained in the font</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0" colspan="2">
-            <widget class="QCheckBox" name="menuAccelCheckBox">
-             <property name="toolTip">
-              <string>Accelerators are activated by Alt and can interfere with the terminal.</string>
-             </property>
-             <property name="text">
-              <string>No menu bar accelerator</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0" colspan="2">
-            <widget class="QCheckBox" name="boldIntenseCheckBox">
-             <property name="toolTip">
-              <string>Toggles usage of bold font face for rendering intense colors</string>
-             </property>
-             <property name="text">
-              <string>Use bold font face for intense colors</string>
-             </property>
-            </widget>
-           </item>
-           <item row="10" column="0" colspan="2">
-            <widget class="QCheckBox" name="borderlessCheckBox">
-             <property name="text">
-              <string>&amp;Hide Window Borders</string>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>
@@ -566,9 +556,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-108</y>
-            <width>421</width>
-            <height>763</height>
+            <y>0</y>
+            <width>490</width>
+            <height>872</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
@@ -585,75 +575,23 @@
              </property>
             </spacer>
            </item>
-           <item row="1" column="0">
-            <widget class="QGroupBox" name="groupBox_4">
-             <property name="title">
-              <string>Emulation</string>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_6">
-              <item row="0" column="0">
-               <widget class="QComboBox" name="emulationComboBox"/>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_2">
-                <property name="text">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which behavior to emulate. Note that this does not have to match your operating system.&lt;/p&gt;&lt;p&gt;If you are not sure, use the &lt;span style=&quot; font-weight:600;&quot;&gt;default&lt;/span&gt; emulation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="textFormat">
-                 <enum>Qt::RichText</enum>
-                </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
            <item row="0" column="0">
             <widget class="QGroupBox" name="groupBox_2">
              <property name="title">
               <string>Behavior</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_2">
-              <item row="3" column="0" colspan="2">
-               <widget class="QCheckBox" name="disableBracketedPasteModeCheckBox">
-                <property name="toolTip">
-                 <string>Bracketed paste mode is useful for pasting multiline strings.</string>
-                </property>
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="historyLimited">
                 <property name="text">
-                 <string>Forcefully disable bracketed paste mode</string>
+                 <string>History size (in lines)</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="2">
-               <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
+              <item row="1" column="0" colspan="2">
+               <widget class="QRadioButton" name="historyUnlimited">
                 <property name="text">
-                 <string>Trim trailing newlines in pasted text</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0" colspan="2">
-               <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
-                <property name="text">
-                 <string>Confirm multiline paste</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0" colspan="2">
-               <widget class="QCheckBox" name="savePosOnExitCheckBox">
-                <property name="text">
-                 <string>Save Position when closing</string>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="1">
-               <widget class="QLineEdit" name="handleHistoryLineEdit"/>
-              </item>
-              <item row="11" column="0" colspan="2">
-               <widget class="QCheckBox" name="useCwdCheckBox">
-                <property name="text">
-                 <string>Open new terminals in current working directory</string>
+                 <string>Unlimited history</string>
                 </property>
                </widget>
               </item>
@@ -670,23 +608,6 @@
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="2">
-               <widget class="QCheckBox" name="askOnExitCheckBox">
-                <property name="text">
-                 <string>Ask for confirmation when closing</string>
-                </property>
-               </widget>
-              </item>
-              <item row="12" column="0" colspan="2">
-               <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
-                <property name="toolTip">
-                 <string>If unchecked the new tab will be opened as the rightmost tab</string>
-                </property>
-                <property name="text">
-                 <string>Open new tab to the right of the active tab</string>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_3">
                 <property name="text">
@@ -694,23 +615,6 @@
                 </property>
                 <property name="buddy">
                  <cstring>motionAfterPasting_comboBox</cstring>
-                </property>
-               </widget>
-              </item>
-              <item row="15" column="0">
-               <widget class="QLabel" name="label_17">
-                <property name="toolTip">
-                 <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>
-                </property>
-                <property name="text">
-                 <string>Handle history command</string>
-                </property>
-               </widget>
-              </item>
-              <item row="9" column="0" colspan="2">
-               <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
-                <property name="text">
-                 <string>Save Size when closing</string>
                 </property>
                </widget>
               </item>
@@ -724,43 +628,27 @@
                 </property>
                </widget>
               </item>
-              <item row="14" column="1">
-               <widget class="QComboBox" name="termComboBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="disableBracketedPasteModeCheckBox">
+                <property name="toolTip">
+                 <string>Bracketed paste mode is useful for pasting multiline strings.</string>
                 </property>
-                <property name="editable">
-                 <bool>true</bool>
-                </property>
-                <property name="currentIndex">
-                 <number>1</number>
-                </property>
-                <item>
-                 <property name="text">
-                  <string notr="true">xterm</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">xterm-256color</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QRadioButton" name="historyLimited">
                 <property name="text">
-                 <string>History size (in lines)</string>
+                 <string>Forcefully disable bracketed paste mode</string>
                 </property>
                </widget>
               </item>
-              <item row="1" column="0" colspan="2">
-               <widget class="QRadioButton" name="historyUnlimited">
+              <item row="4" column="0" colspan="2">
+               <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
                 <property name="text">
-                 <string>Unlimited history</string>
+                 <string>Confirm multiline paste</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0" colspan="2">
+               <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
+                <property name="text">
+                 <string>Trim trailing newlines in pasted text</string>
                 </property>
                </widget>
               </item>
@@ -771,6 +659,27 @@
                 </property>
                 <property name="checked">
                  <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="2">
+               <widget class="QCheckBox" name="askOnExitCheckBox">
+                <property name="text">
+                 <string>Ask for confirmation when closing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="0" colspan="2">
+               <widget class="QCheckBox" name="savePosOnExitCheckBox">
+                <property name="text">
+                 <string>Save Position when closing</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="0" colspan="2">
+               <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
+                <property name="text">
+                 <string>Save Size when closing</string>
                 </property>
                </widget>
               </item>
@@ -832,10 +741,91 @@
                 </item>
                </layout>
               </item>
+              <item row="11" column="0" colspan="2">
+               <widget class="QCheckBox" name="useCwdCheckBox">
+                <property name="text">
+                 <string>Open new terminals in current working directory</string>
+                </property>
+               </widget>
+              </item>
+              <item row="12" column="0" colspan="2">
+               <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
+                <property name="toolTip">
+                 <string>If unchecked the new tab will be opened as the rightmost tab</string>
+                </property>
+                <property name="text">
+                 <string>Open new tab to the right of the active tab</string>
+                </property>
+               </widget>
+              </item>
               <item row="13" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="1">
+               <widget class="QComboBox" name="termComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="editable">
+                 <bool>true</bool>
+                </property>
+                <property name="currentIndex">
+                 <number>1</number>
+                </property>
+                <item>
+                 <property name="text">
+                  <string notr="true">xterm</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">xterm-256color</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="15" column="1">
+               <widget class="QLineEdit" name="handleHistoryLineEdit"/>
+              </item>
+              <item row="15" column="0">
+               <widget class="QLabel" name="label_17">
+                <property name="toolTip">
+                 <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>
+                </property>
+                <property name="text">
+                 <string>Handle history command</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QGroupBox" name="groupBox_4">
+             <property name="title">
+              <string>Emulation</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_6">
+              <item row="0" column="0">
+               <widget class="QComboBox" name="emulationComboBox"/>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which behavior to emulate. Note that this does not have to match your operating system.&lt;/p&gt;&lt;p&gt;If you are not sure, use the &lt;span style=&quot; font-weight:600;&quot;&gt;default&lt;/span&gt; emulation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="wordWrap">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>
@@ -992,28 +982,6 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
      </widget>
      <widget class="QWidget" name="bookmarksPage">
       <layout class="QGridLayout" name="gridLayout_9">
-       <item row="3" column="0">
-        <widget class="QGroupBox" name="groupBox_5">
-         <property name="title">
-          <string>Edit bookmark file contents</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_10">
-          <item row="0" column="0">
-           <widget class="QPlainTextEdit" name="bookmarkPlainEdit">
-            <property name="font">
-             <font>
-              <family>Bera Sans Mono [bitstream]</family>
-              <pointsize>11</pointsize>
-             </font>
-            </property>
-            <property name="lineWrapMode">
-             <enum>QPlainTextEdit::NoWrap</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QCheckBox" name="useBookmarksCheckBox">
          <property name="text">
@@ -1055,50 +1023,44 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QGroupBox" name="groupBox_5">
+         <property name="title">
+          <string>Edit bookmark file contents</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_10">
+          <item row="0" column="0">
+           <widget class="QPlainTextEdit" name="bookmarkPlainEdit">
+            <property name="font">
+             <font>
+              <family>Bera Sans Mono [bitstream]</family>
+              <pointsize>11</pointsize>
+             </font>
+            </property>
+            <property name="lineWrapMode">
+             <enum>QPlainTextEdit::NoWrap</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>listWidget</tabstop>
-  <tabstop>changeFontButton</tabstop>
-  <tabstop>colorSchemaCombo</tabstop>
-  <tabstop>styleComboBox</tabstop>
-  <tabstop>scrollBarPos_comboBox</tabstop>
-  <tabstop>tabsPos_comboBox</tabstop>
-  <tabstop>keybCursorShape_comboBox</tabstop>
-  <tabstop>showMenuCheckBox</tabstop>
-  <tabstop>hideTabBarCheckBox</tabstop>
-  <tabstop>highlightCurrentCheckBox</tabstop>
-  <tabstop>changeWindowTitleCheckBox</tabstop>
-  <tabstop>changeWindowIconCheckBox</tabstop>
-  <tabstop>enabledBidiSupportCheckBox</tabstop>
-  <tabstop>appTransparencyBox</tabstop>
-  <tabstop>termTransparencyBox</tabstop>
-  <tabstop>backgroundImageLineEdit</tabstop>
-  <tabstop>chooseBackgroundImageButton</tabstop>
-  <tabstop>terminalPresetComboBox</tabstop>
-  <tabstop>historyLimited</tabstop>
-  <tabstop>historyLimitedTo</tabstop>
-  <tabstop>historyUnlimited</tabstop>
-  <tabstop>motionAfterPasting_comboBox</tabstop>
-  <tabstop>askOnExitCheckBox</tabstop>
-  <tabstop>savePosOnExitCheckBox</tabstop>
-  <tabstop>saveSizeOnExitCheckBox</tabstop>
-  <tabstop>useCwdCheckBox</tabstop>
-  <tabstop>openNewTabRightToActiveTabCheckBox</tabstop>
-  <tabstop>emulationComboBox</tabstop>
-  <tabstop>shortcutsWidget</tabstop>
-  <tabstop>dropShowOnStartCheckBox</tabstop>
-  <tabstop>dropHeightSpinBox</tabstop>
-  <tabstop>dropWidthSpinBox</tabstop>
-  <tabstop>useBookmarksCheckBox</tabstop>
-  <tabstop>bookmarksLineEdit</tabstop>
-  <tabstop>bookmarksButton</tabstop>
-  <tabstop>bookmarkPlainEdit</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Affected files:
- src/forms/propertiesdialog.ui

The other .ui files had correct tab order.