### PR TITLE
Avoid null pointer dereference

### DIFF
--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -397,10 +397,9 @@ void TermWidgetHolder::setCurrentTerminal(TermWidget* term)
 void TermWidgetHolder::handle_finished()
 {
     TermWidget * w = qobject_cast<TermWidget*>(sender());
-    if (!w)
+    if (w == nullptr)
     {
-        qDebug() << "TermWidgetHolder::handle_finished: Unknown object to handle" << w;
-        assert(0);
+        qFatal("TermWidgetHolder::handle_finished: Unknown object to handle");
     }
     splitCollapse(w);
 }


### PR DESCRIPTION
If w is nullptr we must not dereference it.
qFatal is a cleaner solution.