### PR TITLE
Add word characters preference option (fixes #1098)

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -69,7 +69,7 @@
       <enum>QFrame::StyledPanel</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="appearancePage">
       <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -101,8 +101,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>440</width>
-            <height>925</height>
+            <width>384</width>
+            <height>775</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
@@ -557,8 +557,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>490</width>
-            <height>872</height>
+            <width>398</width>
+            <height>771</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
@@ -621,14 +621,24 @@
               <item row="2" column="1">
                <widget class="QComboBox" name="motionAfterPasting_comboBox"/>
               </item>
-              <item row="14" column="0">
-               <widget class="QLabel" name="label_14">
+              <item row="3" column="0">
+               <widget class="QLabel" name="label_18">
                 <property name="text">
-                 <string>Default $TERM</string>
+                 <string>Word selection characters</string>
                 </property>
                </widget>
               </item>
-              <item row="3" column="0" colspan="2">
+              <item row="3" column="1">
+               <widget class="QLineEdit" name="wordCharactersLineEdit">
+                <property name="toolTip">
+                 <string>When selecting text by word, consider these characters as part of words in addition to alphanumeric characters</string>
+                </property>
+                <property name="text">
+                 <string>:@-./_~</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0" colspan="2">
                <widget class="QCheckBox" name="disableBracketedPasteModeCheckBox">
                 <property name="toolTip">
                  <string>Bracketed paste mode is useful for pasting multiline strings.</string>
@@ -638,21 +648,21 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0" colspan="2">
+              <item row="5" column="0" colspan="2">
                <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
                 <property name="text">
                  <string>Confirm multiline paste</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="2">
+              <item row="6" column="0" colspan="2">
                <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
                 <property name="text">
                  <string>Trim trailing newlines in pasted text</string>
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="2">
+              <item row="7" column="0" colspan="2">
                <widget class="QCheckBox" name="closeTabOnMiddleClickCheckBox">
                 <property name="text">
                  <string>Close tab on middle-click</string>
@@ -662,28 +672,28 @@
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="2">
+              <item row="8" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
                  <string>Ask for confirmation when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="2">
+              <item row="9" column="0" colspan="2">
                <widget class="QCheckBox" name="savePosOnExitCheckBox">
                 <property name="text">
                  <string>Save Position when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="0" colspan="2">
+              <item row="10" column="0" colspan="2">
                <widget class="QCheckBox" name="saveSizeOnExitCheckBox">
                 <property name="text">
                  <string>Save Size when closing</string>
                 </property>
                </widget>
               </item>
-              <item row="10" column="0" colspan="2">
+              <item row="11" column="0" colspan="2">
                <layout class="QHBoxLayout" name="horizontalLayout_4">
                 <property name="spacing">
                  <number>5</number>
@@ -741,14 +751,14 @@
                 </item>
                </layout>
               </item>
-              <item row="11" column="0" colspan="2">
+              <item row="12" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="12" column="0" colspan="2">
+              <item row="13" column="0" colspan="2">
                <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
                 <property name="toolTip">
                  <string>If unchecked the new tab will be opened as the rightmost tab</string>
@@ -758,14 +768,21 @@
                 </property>
                </widget>
               </item>
-              <item row="13" column="0">
+              <item row="14" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
                 </property>
                </widget>
               </item>
-              <item row="14" column="1">
+              <item row="15" column="0">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>Default $TERM</string>
+                </property>
+               </widget>
+              </item>
+              <item row="15" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -791,10 +808,10 @@
                 </item>
                </widget>
               </item>
-              <item row="15" column="1">
+              <item row="16" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
-              <item row="15" column="0">
+              <item row="16" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -161,6 +161,7 @@ void Properties::loadSettings()
 
     confirmMultilinePaste = m_settings->value(QLatin1String("ConfirmMultilinePaste"), false).toBool();
     trimPastedTrailingNewlines = m_settings->value(QLatin1String("TrimPastedTrailingNewlines"), false).toBool();
+    wordCharacters = m_settings->value(QLatin1String("WordCharacters"), QLatin1String(":@-./_~")).toString();
 
     windowMaximized = m_settings->value(QLatin1String("LastWindowMaximized"), false).toBool();
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -122,6 +122,7 @@ class Properties
 
         bool confirmMultilinePaste;
         bool trimPastedTrailingNewlines;
+        QString wordCharacters;
 
         bool windowMaximized;
         bool swapMouseButtons2and3;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -199,6 +199,9 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     disableBracketedPasteModeCheckBox->setChecked(Properties::Instance()->m_disableBracketedPasteMode);
 
+    // word characters for text selection
+    wordCharactersLineEdit->setText(Properties::Instance()->wordCharacters);
+
     // Setting windows style actions
     styleComboBox->addItem(tr("System Default"));
     styleComboBox->addItems(QStyleFactory::keys());
@@ -390,6 +393,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
     Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();
+    Properties::Instance()->wordCharacters = wordCharactersLineEdit->text();
 
     emit propertiesChanged();
 }

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -111,6 +111,7 @@ void TermWidgetImpl::propertiesChanged()
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
     disableBracketedPasteMode(Properties::Instance()->m_disableBracketedPasteMode);
     setConfirmMultilinePaste(Properties::Instance()->confirmMultilinePaste);
+    setWordCharacters(Properties::Instance()->wordCharacters);
     setTrimPastedTrailingNewlines(Properties::Instance()->trimPastedTrailingNewlines);
     setTerminalSizeHint(Properties::Instance()->showTerminalSizeHint);
 


### PR DESCRIPTION
gnome-terminal supports configuring word selection characters, but QTerminal doesn't. This PR adds a configuration option to address that shortcoming.

I was going to make a feature request, but I found [this feature request](https://github.com/lxqt/qterminal/issues/1098) that beat me to it. @yan12125 had a partial implementation that I referenced, but I discovered that it was going to require a change to QTermWidget as well.

QTermWidget dependency: https://github.com/lxqt/qtermwidget/pull/531

