### PR TITLE
save word characters preference to disk

### DIFF
--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -274,6 +274,7 @@ void Properties::saveSettings()
 
     m_settings->setValue(QLatin1String("ConfirmMultilinePaste"), confirmMultilinePaste);
     m_settings->setValue(QLatin1String("TrimPastedTrailingNewlines"), trimPastedTrailingNewlines);
+    m_settings->setValue(QLatin1String("WordCharacters"), wordCharacters);
 
     m_settings->setValue(QLatin1String("LastWindowMaximized"), windowMaximized);
     m_settings->setValue(QLatin1String("SwapMouseButtons2and3"), swapMouseButtons2and3);


### PR DESCRIPTION
In [my previous PR](https://github.com/lxqt/qterminal/pull/1101) I mistakenly forgot to save the new preference to the settings.