### PR TITLE
Set layer overlay for dropdown terminal on wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,13 @@ endif()
 set(LXQTBT_MINIMUM_VERSION "2.0.0")
 set(QT_MINIMUM_VERSION "6.6.0")
 set(QT_MAJOR_VERSION "6")
+set(SHELLQT_MINIMUM_VERSION "6.0.0")
 
 find_package(Qt6Core ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Gui ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
+find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
 if(UNIX)
     find_package(Qt6DBus ${QT_MINIMUM_VERSION} REQUIRED)
     find_package(Qt6 COMPONENTS Core REQUIRED)
@@ -206,6 +208,7 @@ target_link_libraries(${EXE_NAME}
     Qt6::Gui
     Qt6::Widgets
     qtermwidget6
+    LayerShellQtInterface
 )
 if(QXT_FOUND)
     target_link_libraries(${EXE_NAME} ${QXT_CORE_LIB} ${QXT_GUI_LIB})

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,6 +44,9 @@
 #include "qterminalapp.h"
 #include "dbusaddressable.h"
 
+#include <LayerShellQt/Shell>
+#include <LayerShellQt/Window>
+
 typedef std::function<bool(MainWindow&, QAction *)> checkfn;
 Q_DECLARE_METATYPE(checkfn)
 
@@ -168,6 +171,21 @@ MainWindow::~MainWindow()
 
 void MainWindow::enableDropMode()
 {
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        winId();
+        if (QWindow *win = windowHandle())
+        {
+            if (LayerShellQt::Window* layershell = LayerShellQt::Window::get(win))
+            {
+                layershell->setLayer(LayerShellQt::Window::Layer::LayerOverlay);
+                layershell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+                LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop};
+                layershell->setAnchors(anchors);
+            }
+        }
+    }
+
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
 
     m_dropLockButton = new QToolButton(this);


### PR DESCRIPTION
Fix for https://github.com/lxqt/qterminal/issues/1111
 
Remaining issues:
- [ ]  Configuration window is below the dropdownterminal and eventually completely unaccessible
- [ ] Consider screen width instead of available width for centering. With a 100% size and a right or left panel it goes out of screen (for the panel-width).
- [ ] Add an info and disable not-working shortcut selection in preferences.