### PR TITLE
Add preliminary single-instance support for drop-down mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ endif()
 set(LXQTBT_MINIMUM_VERSION "2.0.0")
 set(QT_MINIMUM_VERSION "6.3.0")
 set(QT_MAJOR_VERSION "6")
-set(SHELLQT_MINIMUM_VERSION "6.0.0")
 
 find_package(Qt6Core ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Gui ${QT_MINIMUM_VERSION} REQUIRED)
@@ -41,8 +40,6 @@ find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 if (BUILD_TESTS)
     find_package(Qt6 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Test)
 endif()
-
-find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
 
 include(LXQtPreventInSourceBuilds)
 include(FindPkgConfig)
@@ -218,7 +215,6 @@ target_link_libraries(${EXE_NAME}
     Qt6::Widgets
     Qt6::Network
     qtermwidget6
-    LayerShellQtInterface
     util
 )
 if(QXT_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,13 @@ endif()
 set(LXQTBT_MINIMUM_VERSION "2.0.0")
 set(QT_MINIMUM_VERSION "6.3.0")
 set(QT_MAJOR_VERSION "6")
+set(SHELLQT_MINIMUM_VERSION "6.0.0")
 
 find_package(Qt6Core ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Gui ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
+find_package(Qt6Network ${QT_MINIMUM_VERSION} REQUIRED)
 if(UNIX)
     find_package(Qt6DBus ${QT_MINIMUM_VERSION} REQUIRED)
     find_package(Qt6 COMPONENTS Core Core5Compat REQUIRED)
@@ -39,6 +41,8 @@ find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 if (BUILD_TESTS)
     find_package(Qt6 ${QT_MINIMUM_VERSION} CONFIG REQUIRED Test)
 endif()
+
+find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
 
 include(LXQtPreventInSourceBuilds)
 include(FindPkgConfig)
@@ -74,6 +78,7 @@ set(EXE_NAME qterminal)
 set(QTERM_SRC
     src/main.cpp
     src/mainwindow.cpp
+    src/instance-locker.cpp
     src/tabbar.cpp
     src/tabwidget.cpp
     src/termwidget.cpp
@@ -91,6 +96,7 @@ set(QTERM_SRC
 set(QTERM_MOC_SRC
     src/qterminalapp.h
     src/mainwindow.h
+    src/instance-locker.h
     src/tabbar.h
     src/tabwidget.h
     src/termwidget.h
@@ -210,7 +216,9 @@ target_link_libraries(${EXE_NAME}
     Qt6::Core
     Qt6::Gui
     Qt6::Widgets
+    Qt6::Network
     qtermwidget6
+    LayerShellQtInterface
     util
 )
 if(QXT_FOUND)

--- a/src/instance-locker.cpp
+++ b/src/instance-locker.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+*   Copyright (C) 2024 by Marcus Britanicus                               *
+*   marcusbritanicus@gmail.com                                            *
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+*   This program is distributed in the hope that it will be useful,       *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+*   GNU General Public License for more details.                          *
+*                                                                         *
+*   You should have received a copy of the GNU General Public License     *
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+***************************************************************************/
+
+#include <unistd.h>
+
+#include "instance-locker.h"
+
+static inline QString getSocketName(QString appId)
+{
+    /** Get the env-var XDG_RUNTIME_DIR */
+    QString sockName = QString::fromUtf8(qgetenv("XDG_RUNTIME_DIR"));
+
+    /** The env-var was not set. We will use /tmp/ */
+    if (not sockName.length())
+    {
+        sockName = QString::fromUtf8("/tmp/");
+    }
+
+    if (not sockName.endsWith(QString::fromUtf8("/")))
+    {
+        sockName += QString::fromUtf8("/");
+    }
+
+    /** Append a random number */
+    sockName += QString::fromUtf8("%1-Scoket-%2").arg(appId).arg(getuid());
+
+    return sockName;
+}
+
+
+InstanceLocker::InstanceLocker(QString appId, QObject *parent) : QObject(parent)
+{
+    mServer = nullptr;
+
+    /* App ID */
+    mAppId = appId;
+
+    /** Get the env-var XDG_RUNTIME_DIR */
+    mSocketName = getSocketName(mAppId);
+
+    /* Lock File */
+    lockFile = new QLockFile(mSocketName + QString::fromUtf8(".lock"));
+
+    /* Try to lock the @lockFile, if it fails, then we're not the first instance */
+    if (lockFile->tryLock())
+    {
+        /* Local Server for communication */
+        mServer = new QLocalServer(this);
+
+        /* Start the server */
+        bool res = mServer->listen(mSocketName);
+
+        /* @res can't be false at the moment, because we're the first instance. */
+        /* The only reason why @res is false, the socket file exists from a previous */
+        /* crash. So delete it and try again. */
+        if (not res && (mServer->serverError() == QAbstractSocket::AddressInUseError))
+        {
+            QLocalServer::removeServer(mSocketName);
+            res = mServer->listen(mSocketName);
+
+            if (!res)
+            {
+                qWarning("InstanceLocker: listen on local socket failed, %s", qPrintable(mServer->errorString()));
+            }
+        }
+    }
+}
+
+
+InstanceLocker::~InstanceLocker()
+{
+    disconnect();
+
+    delete lockFile;
+}
+
+
+bool InstanceLocker::isRunning()
+{
+    /* If we have the lock, we're the server */
+    /* In other words, if we're not there, there is no server */
+    if (lockFile->isLocked())
+    {
+        return false;
+    }
+
+    /* If we cannot get the lock then the server is running elsewhere */
+    if (not lockFile->tryLock())
+    {
+        return true;
+    }
+
+    /* Be default, we'll assume that the server is running elsewhere */
+    return true;
+}
+
+
+bool InstanceLocker::sendMessage(const QString& message, int timeout)
+{
+    if (not isRunning())
+    {
+        return false;
+    }
+
+    /* Preparing socket */
+    QLocalSocket socket(this);
+
+    /* Connecting to server */
+    socket.connectToServer(mSocketName);
+
+    /* Wait for ACK (500 ms) */
+    if (not socket.waitForConnected(timeout))
+    {
+        return false;
+    }
+
+    /* Send the message to the server */
+    socket.write(message.toUtf8());
+
+    /** Should finish writing in 500 ms */
+    return socket.waitForBytesWritten(timeout);
+}
+
+
+void InstanceLocker::disconnect()
+{
+    if (mServer)
+    {
+        mServer->close();
+    }
+
+    lockFile->unlock();
+}
+
+
+QString InstanceLocker::handleConnection()
+{
+    /* Preparing socket */
+    QLocalSocket *socket = mServer->nextPendingConnection();
+
+    if (socket == nullptr)
+    {
+        return QString();
+    }
+
+    socket->waitForReadyRead(2000);
+    QByteArray msg = socket->readAll();
+
+    /** Close the connection */
+    socket->close();
+
+    return QString::fromUtf8(msg);
+}

--- a/src/instance-locker.h
+++ b/src/instance-locker.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+*   Copyright (C) 2024 by Marcus Britanicus                               *
+*   marcusbritanicus@gmail.com                                            *
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+*   This program is distributed in the hope that it will be useful,       *
+*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+*   GNU General Public License for more details.                          *
+*                                                                         *
+*   You should have received a copy of the GNU General Public License     *
+*   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+***************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QLockFile>
+#include <QLocalServer>
+#include <QLocalSocket>
+
+class InstanceLocker : public QObject {
+Q_OBJECT
+
+public:
+InstanceLocker(QString appId, QObject *parent = nullptr);
+~InstanceLocker();
+
+/** Check if another isntance is running */
+bool isRunning();
+
+/** Send a message to the original instance */
+bool sendMessage(const QString& message, int timeout = 500);
+
+/** Disconnect from the server */
+void disconnect();
+
+QString handleConnection();
+
+QLockFile *lockFile = nullptr;
+bool mLocked        = false;
+
+QString mSocketName;
+QString mAppId;
+
+QLocalServer *mServer;
+};


### PR DESCRIPTION
This PR adds preliminary support for single instance mode for drop-down mode. Additionally, it adds support for toggling the drop-down instance via `qterminal -d` command line. On wayland, we can simply add a command-binding pair for most compositors. On wayfire, this would simply be adding the following lines under the `[command]` section.

```
binding_qterminal_dd: KEY_F12
command_qterminal_dd: qterminal -d
```

If an instance of qterminal in the drop-down mode exists, it will toggle it. Otherwise, a new drop-down instance will be created. The normal qterminal instances are unaffected.

This fixes both #1028 and #1059. Since it's not possible to fix one without the other, I am breaking the one-issue-one-PR rule.

Cc: @yan12125 @stefonarch @tsujan 
