### PR TITLE
Silenced Qt6 compilation warnings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,25 +178,30 @@ int main(int argc, char *argv[])
     // install the translations built-into Qt itself
     QTranslator qtTranslator;
     if (qtTranslator.load(QStringLiteral("qt_") + QLocale::system().name(), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+    {
         app->installTranslator(&qtTranslator);
+    }
 
     QTranslator translator;
+    bool installTr = false;
     QString fname = QString::fromLatin1("qterminal_%1.qm").arg(QLocale::system().name().left(5));
 #ifdef TRANSLATIONS_DIR
     //qDebug() << "TRANSLATIONS_DIR: Loading translation file" << fname << "from dir" << TRANSLATIONS_DIR;
-    /*qDebug() << "load success:" <<*/ translator.load(fname, QString::fromUtf8(TRANSLATIONS_DIR), QStringLiteral("_"));
+    installTr = translator.load(fname, QString::fromUtf8(TRANSLATIONS_DIR), QStringLiteral("_"));
 #endif
 #ifdef APPLE_BUNDLE
     QDir translations_dir = QDir(QApplication::applicationDirPath());
     translations_dir.cdUp();
     if (translations_dir.cd(QStringLiteral("Resources/translations"))) {
-        //qDebug() << "APPLE_BUNDLE: Loading translator file" << fname << "from dir" << translations_dir.path();
-        /*qDebug() << "load success:" <<*/ translator.load(fname, translations_dir.path(), QStringLiteral("_"));
+        installTr = translator.load(fname, translations_dir.path(), QStringLiteral("_"));
     } /*else {
         qWarning() << "Unable to find \"Resources/translations\" dir in" << translations_dir.path();
     }*/
 #endif
-    app->installTranslator(&translator);
+    if (installTr)
+    {
+        app->installTranslator(&translator);
+    }
 
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
     app->newWindow(dropMode, initConfig);

--- a/src/terminalconfig.cpp
+++ b/src/terminalconfig.cpp
@@ -80,14 +80,14 @@ TerminalConfig TerminalConfig::fromDbus(const QHash<QString,QVariant> &termArgsC
 
 static QString variantToString(const QVariant& variant, QString &defaultVal)
 {
-    if (variant.typeId() == QMetaType::type("QString"))
+    if (variant.typeId() == QMetaType::QString)
         return qvariant_cast<QString>(variant);
     return defaultVal;
 }
 
 static QStringList variantToStringList(const QVariant& variant, QStringList &defaultVal)
 {
-    if (variant.typeId() == QMetaType::type("QStringList"))
+    if (variant.typeId() == QMetaType::QStringList)
         return qvariant_cast<QStringList>(variant);
     return defaultVal;
 }

--- a/src/third-party/qxtglobalshortcut.cpp
+++ b/src/third-party/qxtglobalshortcut.cpp
@@ -64,15 +64,15 @@ QxtGlobalShortcutPrivate::~QxtGlobalShortcutPrivate()
 bool QxtGlobalShortcutPrivate::setShortcut(const QKeySequence& shortcut)
 {
     Qt::KeyboardModifiers allMods = Qt::ShiftModifier | Qt::ControlModifier | Qt::AltModifier | Qt::MetaModifier;
-    key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key((shortcut[0] ^ allMods) & shortcut[0]);
-    mods = shortcut.isEmpty() ? Qt::KeyboardModifiers() : Qt::KeyboardModifiers(shortcut[0] & allMods);
+    key = shortcut.isEmpty() ? Qt::Key(0) : Qt::Key((shortcut[0].key() ^ allMods) & shortcut[0].key());
+    mods = shortcut.isEmpty() ? Qt::KeyboardModifiers() : Qt::KeyboardModifiers(shortcut[0].key() & allMods);
     const quint32 nativeKey = nativeKeycode(key);
     const quint32 nativeMods = nativeModifiers(mods);
     const bool res = registerShortcut(nativeKey, nativeMods);
     if (res)
         shortcuts.insert(qMakePair(nativeKey, nativeMods), &qxt_p());
     else
-        qWarning() << "QxtGlobalShortcut failed to register:" << QKeySequence(key + mods).toString();
+        qWarning() << "QxtGlobalShortcut failed to register:" << QKeySequence(key | mods).toString();
     return res;
 }
 
@@ -86,7 +86,7 @@ bool QxtGlobalShortcutPrivate::unsetShortcut()
     if (res)
         shortcuts.remove(qMakePair(nativeKey, nativeMods));
     else
-        qWarning() << "QxtGlobalShortcut failed to unregister:" << QKeySequence(key + mods).toString();
+        qWarning() << "QxtGlobalShortcut failed to unregister:" << QKeySequence(key | mods).toString();
     key = Qt::Key(0);
     mods = Qt::KeyboardModifiers();
     return res;


### PR DESCRIPTION
All of them were trivial.

Strangely enough, the file `qxtglobalshortcut.cpp` had the MS-Windows newline character, which was corrected by FeatherPad on saving. That's the cause of what you see on GitHub. Use a GUI diff tool (like kdiff3) to see the real difference.