### PR TITLE
Pre-release changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 qterminal-2.0.1 / 2024-06-27
 =============================
  * Single instance for drop-down mode.
+ * Used layer shell for the drop-down mode under Wayland.
  * Prevented a crash on entering `exit` when bookmark dock is shown.
  * Fixed the window height in drop-down mode.
  * Set `QTERMWIDGET_MINIMUM_VERSION`, which was missing after Qt6 port.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+qterminal-2.0.1 / 2024-06-27
+=============================
+ * Single instance for drop-down mode.
+ * Prevented a crash on entering `exit` when bookmark dock is shown.
+ * Fixed the window height in drop-down mode.
+
 qterminal-2.0.0 / 2024-05-17
 =============================
  * Ported to Qt6.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ qterminal-2.0.1 / 2024-06-27
  * Single instance for drop-down mode.
  * Prevented a crash on entering `exit` when bookmark dock is shown.
  * Fixed the window height in drop-down mode.
+ * Set `QTERMWIDGET_MINIMUM_VERSION`, which was missing after Qt6 port.
 
 qterminal-2.0.0 / 2024-05-17
 =============================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(qterminal)
 include(GNUInstallDirs)
 
 # qterminal version
-set(QTERMINAL_VERSION "2.0.0")
+set(QTERMINAL_VERSION "2.0.1")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 option(BUILD_TESTS "Builds tests" ON)
@@ -22,6 +22,7 @@ endif()
 
 # Minimum Versions
 set(LXQTBT_MINIMUM_VERSION "2.0.0")
+set(QTERMWIDGET_MINIMUM_VERSION "2.0.1")
 set(QT_MINIMUM_VERSION "6.6.0")
 set(QT_MAJOR_VERSION "6")
 set(SHELLQT_MINIMUM_VERSION "6.0.0")


### PR DESCRIPTION
Also set `QTERMWIDGET_MINIMUM_VERSION`, which was missing after Qt6 port.