### PR TITLE
Prevent ordinary main windows under dropdown process

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -876,8 +876,22 @@ void MainWindow::newTerminalWindow()
     if (ch)
         cfg.provideCurrentDirectory(ch->currentTerminal()->impl()->workingDirectory());
 
-    MainWindow *w = new MainWindow(cfg, false);
-    w->show();
+    if (m_dropMode)
+    { // the dropdown process has only one (dropdown) main window
+        QStringList args;
+        args <<  QStringLiteral("-w") << cfg.getWorkingDirectory();
+        QString profile = Properties::Instance()->profile();
+        if (!profile.isEmpty())
+        {
+            args << QStringLiteral("-p") << profile;
+        }
+        QProcess::startDetached(QStringLiteral("qterminal"), args);
+    }
+    else
+    {
+        MainWindow *w = new MainWindow(cfg, false);
+        w->show();
+    }
 }
 
 void MainWindow::bookmarksWidget_callCommand(const QString& cmd)

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -416,3 +416,8 @@ QString Properties::configDir() const
     return QFileInfo(m_settings->fileName()).absoluteDir().canonicalPath();
 }
 
+QString Properties::profile() const
+{
+    return filename;
+}
+

--- a/src/properties.h
+++ b/src/properties.h
@@ -42,6 +42,7 @@ class Properties
         void loadSettings();
         void migrate_settings();
         QString configDir() const;
+        QString profile() const;
 
         static void removeAccelerator(QString& str);
 


### PR DESCRIPTION
When a new main window is opened in the dropdown mode (menubar → File → New Window), it should have a separate process because the dropdown process is supposed to consist of a single dropdown window. Of course, the work directory and profile must be respected too.

Fixes https://github.com/lxqt/qterminal/issues/1153