### PR TITLE
Add CMake option to disable Wayland support code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(QTERMINAL_VERSION "2.0.1")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 option(BUILD_TESTS "Builds tests" ON)
+option(ENABLE_WAYLAND "Enable additional support code for the Wayland display server" ON)
 
 if(APPLE)
     option(APPLEBUNDLE "Build as qterminal.app bundle" ON)
@@ -31,7 +32,9 @@ find_package(Qt6Core ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Gui ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
-find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
+if(ENABLE_WAYLAND)
+    find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
+endif()
 if(UNIX)
     find_package(Qt6DBus ${QT_MINIMUM_VERSION} REQUIRED)
     find_package(Qt6 COMPONENTS Core REQUIRED)
@@ -209,8 +212,11 @@ target_link_libraries(${EXE_NAME}
     Qt6::Gui
     Qt6::Widgets
     qtermwidget6
-    LayerShellQtInterface
 )
+if(ENABLE_WAYLAND)
+    add_definitions(-DHAVE_LAYERSHELLQT)
+    target_link_libraries(${EXE_NAME} LayerShellQtInterface)
+endif()
 if(QXT_FOUND)
     target_link_libraries(${EXE_NAME} ${QXT_CORE_LIB} ${QXT_GUI_LIB})
 endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,6 +213,13 @@ int main(int argc, char *argv[])
         app->installTranslator(&translator);
     }
 
+#ifndef HAVE_LAYERSHELLQT
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        fprintf(stderr, "Running on Wayland, although Wayland support was disabled at compile-time. Expect errors.\n");
+    }
+#endif
+
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
     app->newWindow(dropMode, initConfig);
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -44,8 +44,10 @@
 #include "qterminalapp.h"
 #include "dbusaddressable.h"
 
+#ifdef HAVE_LAYERSHELLQT
 #include <LayerShellQt/Shell>
 #include <LayerShellQt/Window>
+#endif
 
 typedef std::function<bool(MainWindow&, QAction *)> checkfn;
 Q_DECLARE_METATYPE(checkfn)
@@ -173,6 +175,7 @@ void MainWindow::enableDropMode()
 {
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
     {
+#ifdef HAVE_LAYERSHELLQT
         winId();
         if (QWindow *win = windowHandle())
         {
@@ -184,6 +187,7 @@ void MainWindow::enableDropMode()
                 layershell->setAnchors(anchors);
             }
         }
+#endif
     }
 
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);


### PR DESCRIPTION
I added a CMake option to disable Wayland support code requiring LayerShellQt.

The dependency on LayerShellQt generates quite a few extra dependencies which are not used for people running QTerminal only on X11.