### PR TITLE
Fullscreen startup option flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,10 +77,11 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
     exit(code);
 }
 
-void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode)
+void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode, out bool& fullScreen)
 {
     int next_option = 0;
     dropMode = false;
+    fullScreen = false;
     do{
         next_option = getopt_long(argc, argv, short_options, long_options, nullptr);
         switch(next_option)
@@ -106,6 +107,9 @@ void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_co
                 break;
             case 'p':
                 Properties::Instance(QString::fromLocal8Bit(optarg));
+                break;
+            case 'f':
+                fullScreen = true;
                 break;
             case '?':
                 print_usage_and_exit(1);
@@ -146,7 +150,8 @@ int main(int argc, char *argv[])
     QString workdir;
     QStringList shell_command;
     bool dropMode = false;
-    parse_args(argc, argv, workdir, shell_command, dropMode);
+    bool fullScreen = false;
+    parse_args(argc, argv, workdir, shell_command, dropMode, fullScreen);
 
     #ifdef HAVE_QDBUS
         app->registerOnDbus(dropMode);
@@ -214,7 +219,7 @@ int main(int argc, char *argv[])
     }
 
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
-    app->newWindow(dropMode, initConfig);
+    app->newWindow(dropMode, fullScreen, initConfig);
 
     int ret = app->exec();
     delete Properties::Instance();
@@ -223,18 +228,18 @@ int main(int argc, char *argv[])
     return ret;
 }
 
-MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg)
+MainWindow *QTerminalApp::newWindow(bool dropMode, bool fullScreen, TerminalConfig &cfg)
 {
     MainWindow *window = nullptr;
     if (dropMode)
     {
-        window = new MainWindow(cfg, dropMode);
+        window = new MainWindow(cfg, dropMode, fullScreen);
         if (Properties::Instance()->dropShowOnStart)
             window->show();
     }
     else
     {
-        window = new MainWindow(cfg, dropMode);
+        window = new MainWindow(cfg, dropMode, fullScreen);
         if (Properties::Instance()->windowMaximized)
             window->setWindowState(Qt::WindowMaximized);
         window->show();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -55,6 +55,7 @@ Q_DECLARE_METATYPE(checkfn)
 
 MainWindow::MainWindow(TerminalConfig &cfg,
                        bool dropMode,
+                       bool fullScreen,
                        QWidget * parent,
                        Qt::WindowFlags f)
     : QMainWindow(parent,f),
@@ -69,7 +70,8 @@ MainWindow::MainWindow(TerminalConfig &cfg,
       presetsMenu(nullptr),
       m_config(cfg),
       m_dropLockButton(nullptr),
-      m_dropMode(dropMode)
+      m_dropMode(dropMode),
+      m_fullScreen(fullScreen)
 {
 #ifdef HAVE_QDBUS
     registerAdapter<WindowAdaptor, MainWindow>(this);
@@ -439,10 +441,10 @@ void MainWindow::setup_ViewMenu_Actions()
 
     QAction *toggleFullscreen = new QAction(tr("Fullscreen"), settingOwner);
     toggleFullscreen->setCheckable(true);
-    toggleFullscreen->setChecked(false);
+    toggleFullscreen->setChecked(m_fullScreen);
+    showFullscreen(m_fullScreen);
     setup_Action(FULLSCREEN, toggleFullscreen,
                  FULLSCREEN_SHORTCUT, this, SLOT(showFullscreen(bool)), menu_Window);
-
     setup_Action(TOGGLE_BOOKMARKS, new QAction(tr("Toggle Bookmarks"), settingOwner),
                  TOGGLE_BOOKMARKS_SHORTCUT, this, SLOT(toggleBookmarks()), menu_Window);
 
@@ -888,8 +890,8 @@ void MainWindow::newTerminalWindow()
         QProcess::startDetached(QStringLiteral("qterminal"), args);
     }
     else
-    {
-        MainWindow *w = new MainWindow(cfg, false);
+    { // fullScreen arg false so additional windows are not started in fullscreen
+        MainWindow *w = new MainWindow(cfg, false, false);
         w->show();
     }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -38,6 +38,7 @@ class MainWindow : public QMainWindow, private Ui::mainWindow, public DBusAddres
 public:
     MainWindow(TerminalConfig& cfg,
                bool dropMode,
+               bool fullScreen,
                QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~MainWindow() override;
 
@@ -86,6 +87,7 @@ private:
     void enableDropMode();
     QToolButton *m_dropLockButton;
     bool m_dropMode;
+    bool m_fullScreen;
     QxtGlobalShortcut m_dropShortcut;
     void realign();
     void setDropShortcut(const QKeySequence& dropShortCut);

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -15,7 +15,7 @@ class QTerminalApp : public QApplication
 Q_OBJECT
 
 public:
-    MainWindow *newWindow(bool dropMode, TerminalConfig &cfg);
+    MainWindow *newWindow(bool dropMode, bool fullScreen, TerminalConfig &cfg);
     QList<MainWindow*> getWindowList();
     void addWindow(MainWindow *window);
     void removeWindow(MainWindow *window);


### PR DESCRIPTION
Added an option flag -f "--fullscreen" which can be used to start qterminal in fullscreen mode.

The flag sets the main window to fullscreen & checks the box for the fullscreen option in the GUI "view" menu.

When a window is opened using the flag, any additional windows created by the main window will not be opened in fullscreen mode.

Resolves issue #796
(Feature request)
