### PR TITLE
Fixed new tab from preset and context menu's collapse action

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -381,8 +381,10 @@ void MainWindow::setup_FileMenu_Actions()
 
     if (presetsMenu == nullptr) {
         presetsMenu = new QMenu(tr("New Tab From &Preset"), this);
-        presetsMenu->addAction(QIcon(), tr("1 &Terminal"),
-                               this, SLOT(addNewTab()));
+        auto a = presetsMenu->addAction(QIcon(), tr("1 &Terminal"));
+        connect(a, &QAction::triggered, consoleTabulator, [this]() {
+            consoleTabulator->addNewTab(m_config);
+        });
         presetsMenu->addAction(QIcon(), tr("2 &Horizontal Terminals"),
                                consoleTabulator, SLOT(preset2Horizontal()));
         presetsMenu->addAction(QIcon(), tr("2 &Vertical Terminals"),

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -87,7 +87,12 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
             this, &PropertiesDialog::chooseBackgroundImageButton_clicked);
 
     // fixed size
-    connect(saveSizeOnExitCheckBox, &QCheckBox::stateChanged, [this] (int state) {
+#if (QT_VERSION >= QT_VERSION_CHECK(6,7,0))
+    connect(saveSizeOnExitCheckBox, &QCheckBox::checkStateChanged, [this] (int state)
+#else
+    connect(saveSizeOnExitCheckBox, &QCheckBox::stateChanged, [this] (int state)
+#endif
+    {
         fixedSizeLabel->setEnabled(state == Qt::Unchecked);
         xLabel->setEnabled(state == Qt::Unchecked);
         fixedWithSpinBox->setEnabled(state == Qt::Unchecked);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -200,6 +200,11 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
     menu.addAction(actions[QStringLiteral(TOGGLE_MENU)]);
     menu.addAction(actions[QStringLiteral(HIDE_WINDOW_BORDERS)]);
     menu.addAction(actions[QStringLiteral(PREFERENCES)]);
+
+    // The disabled actions should be updated before showing the menu because
+    // the "Actions" menu of the main window may have not been shown yet.
+    mainWindow->updateDisabledActions();
+
     menu.exec(mapToGlobal(pos));
 }
 


### PR DESCRIPTION
This patch fixes two bugs when the terminal is started with a preset of N > 1 terminals:

 * Previously, the action "New tab from preset" didn't work correctly when the number of preset was less than N.
 * Also, if the terminal context menu was the first menu that was opened, the action "Collapse Subterminal" would be disabled.

I also silenced a compilation warning about `&QCheckBox::stateChanged`.

Fixes https://github.com/lxqt/qterminal/issues/1104