### PR TITLE
Hide/disable some options on Wayland

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -275,7 +275,7 @@
             </widget>
            </item>
            <item row="11" column="0">
-            <widget class="QLabel" name="label_4">
+            <widget class="QLabel" name="appTransparencyLabel">
              <property name="text">
               <string>Application transparency</string>
              </property>

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -297,7 +297,14 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
         Properties::Instance()->saveSettings();
     });
 
-    waylandLabel->setVisible(QGuiApplication::platformName() == QStringLiteral("wayland"));
+    // show, hide or disable some widgets on Wayland
+    bool onWayland(QGuiApplication::platformName() == QStringLiteral("wayland"));
+    appTransparencyLabel->setVisible(!onWayland);
+    appTransparencyBox->setVisible(!onWayland);
+    savePosOnExitCheckBox->setVisible(!onWayland);
+    waylandLabel->setVisible(onWayland);
+    dropShortCutLabel->setEnabled(!onWayland);
+    dropShortCutEdit->setEnabled(!onWayland);
 
     // restore its size while fitting it into available desktop geometry
     QSize s;


### PR DESCRIPTION
The app transparency widget and the position saving box are hidden. The dropdown shortcut widget is disabled because it has a label on Wayland.