### PR TITLE
Prompt on closing with a running process

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -825,7 +825,7 @@
               <item row="7" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
-                 <string>Ask for confirmation when closing</string>
+                 <string>Prompt on closing with a running process</string>
                 </property>
                </widget>
               </item>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -49,6 +49,8 @@ public:
 
     void rebuildActions();
 
+    bool closePrompt(const QString &title, const QString &text);
+
     #ifdef HAVE_QDBUS
     QDBusObjectPath getActiveTab();
     QList<QDBusObjectPath> getTabs();

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -49,9 +49,11 @@ public:
     void showHideTabBar();
     const QList<QWidget*>& history() const;
 
+    bool hasRunningProcess() const;
+
 public slots:
     int addNewTab(TerminalConfig cfg);
-    void removeTab(int);
+    void removeTab(int index, bool prompt = false);
     void switchTab(int);
     void onAction();
     void onCurrentChanged(int);

--- a/src/terminalconfig.cpp
+++ b/src/terminalconfig.cpp
@@ -46,6 +46,11 @@ QStringList TerminalConfig::getShell()
     return QStringList();
 }
 
+bool TerminalConfig::hasCommand() const
+{
+    return !m_shell.isEmpty();
+}
+
 void TerminalConfig::setWorkingDirectory(const QString &val)
 {
     m_workingDirectory = val;

--- a/src/terminalconfig.h
+++ b/src/terminalconfig.h
@@ -17,6 +17,7 @@ class TerminalConfig
 
         QString getWorkingDirectory();
         QStringList getShell();
+        bool hasCommand() const;
 
         void setWorkingDirectory(const QString &val);
         void setShell(const QStringList &val);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -57,6 +57,8 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     setFlowControlEnabled(FLOW_CONTROL_ENABLED);
     setFlowControlWarningEnabled(FLOW_CONTROL_WARNING_ENABLED);
 
+    m_hasCommand = cfg.hasCommand();
+
     propertiesChanged();
 
     setWorkingDirectory(cfg.getWorkingDirectory());

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -43,6 +43,10 @@ class TermWidgetImpl : public QTermWidget
         virtual ~TermWidgetImpl();
         void propertiesChanged();
 
+        bool hasCommand() const {
+            return m_hasCommand;
+        }
+
     signals:
         void renameSession();
         void removeCurrentSession();
@@ -58,6 +62,7 @@ class TermWidgetImpl : public QTermWidget
         void bell();
 
     private:
+        bool m_hasCommand;
 #ifdef HAVE_LIBCANBERRA
         ca_context* libcanberra_context;
 #endif

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -409,6 +409,22 @@ void TermWidgetHolder::onTermTitleChanged(QString title, QString icon) const
         emit termTitleChanged(std::move(title), std::move(icon));
 }
 
+bool TermWidgetHolder::hasRunningProcess() const
+{
+    const QList<TermWidget*> list = findChildren<TermWidget*>();
+    for (const auto &term : list)
+    {
+        if (auto impl = term->impl())
+        {
+            if (impl->hasCommand() || impl->getForegroundProcessId() != impl->getShellPID())
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 #ifdef HAVE_QDBUS
 
 QDBusObjectPath TermWidgetHolder::getActiveTerminal()

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -65,6 +65,8 @@ class TermWidgetHolder : public QWidget
         TermWidget* currentTerminal();
         TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg);
 
+        bool hasRunningProcess() const;
+
         #ifdef HAVE_QDBUS
         QDBusObjectPath getActiveTerminal();
         QList<QDBusObjectPath> getTerminals();


### PR DESCRIPTION
Previously, the closing prompt was useful only when there was a running process in the terminal, but the code didn't check that. A prompt without a running process was redundant.

This patch gives a real job to the closing prompt by making it work only when there is a running process, whether when the main window is going to be closed, or when a subterminal is going to be collapsed.

To detect a running process, the code makes use of @marcusbritanicus's commit https://github.com/lxqt/qtermwidget/commit/ccb3b2132d3c7d4b19b9a3221f9c4dcf13eee9dc by comparing `getForegroundProcessId()` with `getShellPID()`. In addition, it checks whether `TerminalConfig` has a command (e.g., when an app is executed in the terminal by the file manager).

Therefore, the config text "Ask for confirmation when closing" is also changed to "Prompt on closing with a running process".