### PR TITLE
Removed app transparency

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -275,32 +275,6 @@
             </widget>
            </item>
            <item row="11" column="0">
-            <widget class="QLabel" name="appTransparencyLabel">
-             <property name="text">
-              <string>Application transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>appTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="1">
-            <widget class="QSpinBox" name="appTransparencyBox">
-             <property name="suffix">
-              <string> %</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>99</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
               <string>Terminal transparency</string>
@@ -310,7 +284,7 @@
              </property>
             </widget>
            </item>
-           <item row="12" column="1">
+           <item row="11" column="1">
             <widget class="QSpinBox" name="termTransparencyBox">
              <property name="suffix">
               <string> %</string>
@@ -326,14 +300,14 @@
              </property>
             </widget>
            </item>
-           <item row="13" column="0">
+           <item row="12" column="0">
             <widget class="QLabel" name="label_13">
              <property name="text">
               <string>Background image:</string>
              </property>
             </widget>
            </item>
-           <item row="13" column="1">
+           <item row="12" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_3">
              <item>
               <widget class="QLineEdit" name="backgroundImageLineEdit"/>
@@ -347,14 +321,14 @@
              </item>
             </layout>
            </item>
-           <item row="14" column="0">
+           <item row="13" column="0">
             <widget class="QLabel" name="label_16">
              <property name="text">
               <string>Background mode:</string>
              </property>
             </widget>
            </item>
-           <item row="14" column="1">
+           <item row="13" column="1">
             <widget class="QComboBox" name="backgroundModecomboBox">
              <item>
               <property name="text">
@@ -383,7 +357,7 @@
              </item>
             </widget>
            </item>
-           <item row="15" column="0">
+           <item row="14" column="0">
             <widget class="QLabel" name="label_9">
              <property name="text">
               <string>Start with preset:</string>
@@ -393,7 +367,7 @@
              </property>
             </widget>
            </item>
-           <item row="15" column="1">
+           <item row="14" column="1">
             <widget class="QComboBox" name="terminalPresetComboBox">
              <item>
               <property name="text">
@@ -417,7 +391,7 @@
              </item>
             </widget>
            </item>
-           <item row="16" column="0">
+           <item row="15" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Terminal margin</string>
@@ -427,14 +401,14 @@
              </property>
             </widget>
            </item>
-           <item row="16" column="1">
+           <item row="15" column="1">
             <widget class="QSpinBox" name="terminalMarginSpinBox">
              <property name="suffix">
               <string>px</string>
              </property>
             </widget>
            </item>
-           <item row="17" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <widget class="QGroupBox" name="currentTerminal">
              <property name="title">
               <string>Current Terminal</string>
@@ -471,7 +445,7 @@
              </layout>
             </widget>
            </item>
-           <item row="18" column="0" colspan="2">
+           <item row="17" column="0" colspan="2">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -730,7 +730,6 @@ void MainWindow::propertiesChanged()
     rebuildActions();
 
     QApplication::setStyle(Properties::Instance()->guiStyle);
-    setWindowOpacity(1.0 - Properties::Instance()->appTransparency/100.0);
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     consoleTabulator->propertiesChanged();
     setDropShortcut(Properties::Instance()->dropShortCut);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -115,7 +115,6 @@ void Properties::loadSettings()
 
     terminalMargin = m_settings->value(QLatin1String("TerminalMargin"), 0).toInt();
 
-    appTransparency = m_settings->value(QLatin1String("MainWindow/ApplicationTransparency"), 0).toInt();
     termTransparency = m_settings->value(QLatin1String("TerminalTransparency"), 0).toInt();
     backgroundImage = m_settings->value(QLatin1String("TerminalBackgroundImage"), QString()).toString();
     backgroundMode = qBound(0, m_settings->value(QLatin1String("TerminalBackgroundMode"), 0).toInt(), 4);
@@ -237,7 +236,6 @@ void Properties::saveSettings()
     }
     m_settings->endArray();
 
-    m_settings->setValue(QLatin1String("MainWindow/ApplicationTransparency"), appTransparency);
     m_settings->setValue(QLatin1String("TerminalMargin"), terminalMargin);
     m_settings->setValue(QLatin1String("TerminalTransparency"), termTransparency);
     m_settings->setValue(QLatin1String("TerminalBackgroundImage"), backgroundImage);
@@ -365,21 +363,6 @@ void Properties::migrate_settings()
             settings.setValue(QLatin1String("HideTabBarWithOneTab"), hideValue);
         }
         settings.remove(QLatin1String("AlwaysShowTabs"));
-
-        // ===== appOpacity -> ApplicationTransparency =====
-        //
-        // Note: In 0.6.0 the opacity values had been erroneously
-        // restricted to [0,99] instead of [1,100]. We fix this here by
-        // setting the opacity to 100 if it was 99 and to 1 if it was 0.
-        //
-        if(!settings.contains(QLatin1String("MainWindow/ApplicationTransparency")))
-        {
-            int appOpacityValue = settings.value(QLatin1String("MainWindow/appOpacity"), 100).toInt();
-            appOpacityValue = appOpacityValue == 99 ? 100 : appOpacityValue;
-            appOpacityValue = appOpacityValue == 0 ? 1 : appOpacityValue;
-            settings.setValue(QLatin1String("MainWindow/ApplicationTransparency"), 100 - appOpacityValue);
-        }
-        settings.remove(QLatin1String("MainWindow/appOpacity"));
 
         // ===== termOpacity -> TerminalTransparency =====
         if(!settings.contains(QLatin1String("TerminalTransparency")))

--- a/src/properties.h
+++ b/src/properties.h
@@ -68,7 +68,6 @@ class Properties
         Sessions sessions;
 
         int terminalMargin;
-        int appTransparency;
         int termTransparency;
         QString backgroundImage;
         int backgroundMode;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -219,8 +219,6 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     terminalMarginSpinBox->setValue(Properties::Instance()->terminalMargin);
 
-    appTransparencyBox->setValue(Properties::Instance()->appTransparency);
-
     termTransparencyBox->setValue(Properties::Instance()->termTransparency);
 
     highlightCurrentCheckBox->setChecked(Properties::Instance()->highlightCurrentTerminal);
@@ -299,8 +297,6 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     // show, hide or disable some widgets on Wayland
     bool onWayland(QGuiApplication::platformName() == QStringLiteral("wayland"));
-    appTransparencyLabel->setVisible(!onWayland);
-    appTransparencyBox->setVisible(!onWayland);
     savePosOnExitCheckBox->setVisible(!onWayland);
     waylandLabel->setVisible(onWayland);
     dropShortCutLabel->setEnabled(!onWayland);
@@ -334,12 +330,6 @@ void PropertiesDialog::apply()
                                        QString() : styleComboBox->currentText();
 
     Properties::Instance()->emulation = emulationComboBox->currentText();
-
-    /* do not allow to go above 99 or we lose transparency option */
-    (appTransparencyBox->value() >= 100) ?
-            Properties::Instance()->appTransparency = 99
-                :
-            Properties::Instance()->appTransparency = appTransparencyBox->value();
 
     Properties::Instance()->terminalMargin = terminalMarginSpinBox->value();
     Properties::Instance()->termTransparency = termTransparencyBox->value();


### PR DESCRIPTION
At least for three reasons:
 1. App transparency isn't for normal windows — it may be used with "desktop widgets" like analog clocks, and even in those cases, it isn't a reliable way of having transparency;
 2. We have terminal transparency; and
 3. App transparency is only for X11, which, ironically, does not support transparency without a compositor.

Closes https://github.com/lxqt/qterminal/issues/1192