### PR TITLE
Initial POC for a colorscheme editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(QTERM_SRC
     src/propertiesdialog.cpp
     src/bookmarkswidget.cpp
     src/fontdialog.cpp
+    src/palettedialog.cpp
     src/dbusaddressable.cpp
     src/tab-switcher.cpp
     src/qterminalutils.cpp
@@ -96,6 +97,7 @@ set(QTERM_MOC_SRC
     src/propertiesdialog.h
     src/bookmarkswidget.h
     src/fontdialog.h
+    src/palettedialog.h
     src/tab-switcher.h
 )
 
@@ -128,6 +130,7 @@ set(QTERM_UI_SRC
     src/forms/propertiesdialog.ui
     src/forms/bookmarkswidget.ui
     src/forms/fontdialog.ui
+    src/forms/palettedialog.ui
 )
 
 set(QTERM_RCC_SRC

--- a/src/forms/palettedialog.ui
+++ b/src/forms/palettedialog.ui
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PaletteDialog</class>
+ <widget class="QDialog" name="PaletteDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>377</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Chose your colors</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="nameLabel">
+     <property name="font">
+      <font>
+       <pointsize>18</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="tiles">
+     <property name="title">
+      <string>Drop a color</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="2">
+       <widget class="QLabel" name="Color4">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Blue</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="Color0Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Dark Gray</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="Color7">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Light Gray</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="Color2Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Green</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="Color0">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Black</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="Color3Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Yellow</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="Foreground">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Foreground</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QLabel" name="Color6Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Cyan</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="Color2">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Green</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="BackgroundIntense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Intense Background</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ForegroundIntense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Intense Foreground</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="Background">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Background</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="Color5">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Magenta</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="Color6">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Cyan</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QLabel" name="Color4Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Blue</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QLabel" name="Color7Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>White</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="Color1Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Red</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="Color1">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Red</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="Color5Intense">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Bright Magenta</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="Color3">
+        <property name="acceptDrops">
+         <bool>true</bool>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::Shape::StyledPanel</enum>
+        </property>
+        <property name="text">
+         <string>Yellow</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignCenter</set>
+        </property>
+        <property name="margin">
+         <number>4</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="colorbutton">
+       <property name="text">
+        <string>Color dialog</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>PaletteDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>313</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>226</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>PaletteDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>226</x>
+     <y>313</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>226</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>700</width>
-    <height>700</height>
+    <width>763</width>
+    <height>638</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Terminal settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_4">
+  <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1">
    <item row="0" column="0">
     <widget class="QListWidget" name="listWidget">
      <item>
@@ -21,8 +21,7 @@
        <string>Appearance</string>
       </property>
       <property name="icon">
-       <iconset theme="preferences-desktop-theme">
-        <normaloff>.</normaloff>.</iconset>
+       <iconset theme="preferences-desktop-theme"/>
       </property>
      </item>
      <item>
@@ -38,8 +37,7 @@
        <string>Behavior</string>
       </property>
       <property name="icon">
-       <iconset theme="preferences-system">
-        <normaloff>.</normaloff>.</iconset>
+       <iconset theme="preferences-system"/>
       </property>
      </item>
      <item>
@@ -47,8 +45,7 @@
        <string>Shortcuts</string>
       </property>
       <property name="icon">
-       <iconset theme="preferences-desktop-keyboard">
-        <normaloff>.</normaloff>.</iconset>
+       <iconset theme="preferences-desktop-keyboard"/>
       </property>
      </item>
      <item>
@@ -56,8 +53,7 @@
        <string>Dropdown</string>
       </property>
       <property name="icon">
-       <iconset theme="utilities-terminal">
-        <normaloff>.</normaloff>.</iconset>
+       <iconset theme="utilities-terminal"/>
       </property>
      </item>
      <item>
@@ -65,8 +61,7 @@
        <string>Bookmarks</string>
       </property>
       <property name="icon">
-       <iconset theme="bookmark-new">
-        <normaloff>.</normaloff>.</iconset>
+       <iconset theme="bookmark-new"/>
       </property>
      </item>
     </widget>
@@ -74,7 +69,7 @@
    <item row="0" column="1">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::Shape::StyledPanel</enum>
      </property>
      <property name="currentIndex">
       <number>0</number>
@@ -99,7 +94,7 @@
        <item>
         <widget class="QScrollArea" name="scrollArea">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
@@ -109,12 +104,118 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>441</width>
-            <height>659</height>
+            <width>460</width>
+            <height>667</height>
            </rect>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="0" rowspan="2" colspan="2">
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>Cursor shape</string>
+             </property>
+             <property name="buddy">
+              <cstring>keybCursorShape_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1" colspan="5">
+            <widget class="QComboBox" name="tabsPos_comboBox"/>
+           </item>
+           <item row="3" column="5">
+            <widget class="QToolButton" name="configNightSchema">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="icon">
+              <iconset theme="QIcon::ThemeIcon::ListAdd"/>
+             </property>
+             <property name="popupMode">
+              <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2" colspan="3">
+            <widget class="QLabel" name="fontSampleLabel">
+             <property name="frameShape">
+              <enum>QFrame::Shape::StyledPanel</enum>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0" colspan="6">
+            <widget class="QCheckBox" name="boldIntenseCheckBox">
+             <property name="toolTip">
+              <string>Toggles usage of bold font face for rendering intense colors</string>
+             </property>
+             <property name="text">
+              <string>Use bold font face for intense colors</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1" colspan="5">
+            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Color scheme</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="text">
+              <string>Tabs position</string>
+             </property>
+             <property name="buddy">
+              <cstring>tabsPos_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="13" column="1" colspan="5">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLineEdit" name="backgroundImageLineEdit"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="chooseBackgroundImageButton">
+               <property name="text">
+                <string>Select</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="13" column="0">
+            <widget class="QLabel" name="label_13">
+             <property name="text">
+              <string>Background image:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="5">
+            <widget class="QPushButton" name="changeFontButton">
+             <property name="text">
+              <string>&amp;Change...</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
             <widget class="QWidget" name="fontWidget" native="true">
              <layout class="QHBoxLayout" name="horizontalLayout_2">
               <property name="leftMargin">
@@ -139,196 +240,10 @@
                 </property>
                </widget>
               </item>
-              <item>
-               <spacer name="fontSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QLabel" name="fontSampleLabel">
-                <property name="frameShape">
-                 <enum>QFrame::StyledPanel</enum>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="wordWrap">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="changeFontButton">
-                <property name="text">
-                 <string>&amp;Change...</string>
-                </property>
-               </widget>
-              </item>
              </layout>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Color scheme</string>
-             </property>
-             <property name="buddy">
-              <cstring>colorSchemaCombo</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="colorSchemaCombo"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Widget style</string>
-             </property>
-             <property name="buddy">
-              <cstring>styleComboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="styleComboBox"/>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Scrollbar position</string>
-             </property>
-             <property name="buddy">
-              <cstring>scrollBarPos_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_8">
-             <property name="text">
-              <string>Tabs position</string>
-             </property>
-             <property name="buddy">
-              <cstring>tabsPos_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="tabsPos_comboBox"/>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="label_12">
-             <property name="text">
-              <string>Cursor shape</string>
-             </property>
-             <property name="buddy">
-              <cstring>keybCursorShape_comboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QComboBox" name="keybCursorShape_comboBox"/>
-           </item>
-           <item row="7" column="0" colspan="2">
-            <widget class="QCheckBox" name="boldIntenseCheckBox">
-             <property name="toolTip">
-              <string>Toggles usage of bold font face for rendering intense colors</string>
-             </property>
-             <property name="text">
-              <string>Use bold font face for intense colors</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0" colspan="2">
-            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
-             <property name="text">
-              <string>Show terminal size on resize</string>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="0" colspan="2">
-            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
-             <property name="text">
-              <string>Enable bi-directional text support</string>
-             </property>
-            </widget>
-           </item>
-           <item row="10" column="0" colspan="2">
-            <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
-             <property name="toolTip">
-              <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
-             </property>
-             <property name="text">
-              <string>Use box drawing characters contained in the font</string>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="0">
-            <widget class="QLabel" name="label">
-             <property name="text">
-              <string>Terminal transparency</string>
-             </property>
-             <property name="buddy">
-              <cstring>termTransparencyBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="11" column="1">
-            <widget class="QSpinBox" name="termTransparencyBox">
-             <property name="suffix">
-              <string> %</string>
-             </property>
-             <property name="minimum">
-              <number>0</number>
-             </property>
-             <property name="maximum">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>0</number>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="0">
-            <widget class="QLabel" name="label_13">
-             <property name="text">
-              <string>Background image:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="12" column="1">
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
-             <item>
-              <widget class="QLineEdit" name="backgroundImageLineEdit"/>
-             </item>
-             <item>
-              <widget class="QPushButton" name="chooseBackgroundImageButton">
-               <property name="text">
-                <string>Select</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item row="13" column="0">
-            <widget class="QLabel" name="label_16">
-             <property name="text">
-              <string>Background mode:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="13" column="1">
+           <item row="14" column="1" colspan="5">
             <widget class="QComboBox" name="backgroundModecomboBox">
              <item>
               <property name="text">
@@ -357,58 +272,7 @@
              </item>
             </widget>
            </item>
-           <item row="14" column="0">
-            <widget class="QLabel" name="label_9">
-             <property name="text">
-              <string>Start with preset:</string>
-             </property>
-             <property name="buddy">
-              <cstring>terminalPresetComboBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="14" column="1">
-            <widget class="QComboBox" name="terminalPresetComboBox">
-             <item>
-              <property name="text">
-               <string>None (single terminal)</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals horizontally</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>2 terminals vertically</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>4 terminals</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="15" column="0">
-            <widget class="QLabel" name="label_15">
-             <property name="text">
-              <string>Terminal margin</string>
-             </property>
-             <property name="buddy">
-              <cstring>terminalMarginSpinBox</cstring>
-             </property>
-            </widget>
-           </item>
-           <item row="15" column="1">
-            <widget class="QSpinBox" name="terminalMarginSpinBox">
-             <property name="suffix">
-              <string>px</string>
-             </property>
-            </widget>
-           </item>
-           <item row="16" column="0" colspan="2">
+           <item row="17" column="0" colspan="6">
             <widget class="QGroupBox" name="currentTerminal">
              <property name="title">
               <string>Current Terminal</string>
@@ -445,10 +309,44 @@
              </layout>
             </widget>
            </item>
-           <item row="17" column="0" colspan="2">
+           <item row="11" column="0" colspan="6">
+            <widget class="QCheckBox" name="useFontBoxDrawingCharsCheckBox">
+             <property name="toolTip">
+              <string>Specify whether box drawing characters should be drawn by QTerminal internally or left to underlying font rendering libraries.</string>
+             </property>
+             <property name="text">
+              <string>Use box drawing characters contained in the font</string>
+             </property>
+            </widget>
+           </item>
+           <item row="15" column="1" colspan="5">
+            <widget class="QComboBox" name="terminalPresetComboBox">
+             <item>
+              <property name="text">
+               <string>None (single terminal)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals horizontally</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2 terminals vertically</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>4 terminals</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="18" column="0">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -457,6 +355,203 @@
               </size>
              </property>
             </spacer>
+           </item>
+           <item row="1" column="1" colspan="4">
+            <widget class="QComboBox" name="colorSchemaCombo"/>
+           </item>
+           <item row="15" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="text">
+              <string>Start with preset:</string>
+             </property>
+             <property name="buddy">
+              <cstring>terminalPresetComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="0">
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Terminal margin</string>
+             </property>
+             <property name="buddy">
+              <cstring>terminalMarginSpinBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0" colspan="6">
+            <widget class="QCheckBox" name="showTerminalSizeHintCheckBox">
+             <property name="text">
+              <string>Show terminal size on resize</string>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Terminal transparency</string>
+             </property>
+             <property name="buddy">
+              <cstring>termTransparencyBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="12" column="1" colspan="5">
+            <widget class="QSpinBox" name="termTransparencyBox">
+             <property name="suffix">
+              <string> %</string>
+             </property>
+             <property name="minimum">
+              <number>0</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1" colspan="5">
+            <widget class="QComboBox" name="styleComboBox"/>
+           </item>
+           <item row="14" column="0">
+            <widget class="QLabel" name="label_16">
+             <property name="text">
+              <string>Background mode:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>Scrollbar position</string>
+             </property>
+             <property name="buddy">
+              <cstring>scrollBarPos_comboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="16" column="1" colspan="5">
+            <widget class="QSpinBox" name="terminalMarginSpinBox">
+             <property name="suffix">
+              <string>px</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1" colspan="5">
+            <widget class="QComboBox" name="scrollBarPos_comboBox"/>
+           </item>
+           <item row="10" column="0" colspan="6">
+            <widget class="QCheckBox" name="enabledBidiSupportCheckBox">
+             <property name="text">
+              <string>Enable bi-directional text support</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0" colspan="6">
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <property name="spacing">
+              <number>20</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="nightSchema">
+               <property name="text">
+                <string>Night scheme from</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QTimeEdit" name="nightSchemaStart">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>21</hour>
+                 <minute>0</minute>
+                 <second>0</second>
+                </time>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_4">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>to</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignmentFlag::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QTimeEdit" name="nightSchemaEnd">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="time">
+                <time>
+                 <hour>7</hour>
+                 <minute>0</minute>
+                 <second>0</second>
+                </time>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Widget style</string>
+             </property>
+             <property name="buddy">
+              <cstring>styleComboBox</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="5">
+            <widget class="QToolButton" name="configColorSchema">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="icon">
+              <iconset theme="QIcon::ThemeIcon::ListAdd"/>
+             </property>
+             <property name="popupMode">
+              <enum>QToolButton::ToolButtonPopupMode::InstantPopup</enum>
+             </property>
+             <property name="toolButtonStyle">
+              <enum>Qt::ToolButtonStyle::ToolButtonIconOnly</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1" colspan="4">
+            <widget class="QComboBox" name="nightSchemaCombo">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -484,7 +579,7 @@
        <item>
         <widget class="QScrollArea" name="scrollArea2">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
@@ -494,8 +589,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>454</width>
-            <height>248</height>
+            <width>382</width>
+            <height>318</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
@@ -627,10 +722,10 @@
              <item>
               <spacer name="horizontalSpacer">
                <property name="orientation">
-                <enum>Qt::Horizontal</enum>
+                <enum>Qt::Orientation::Horizontal</enum>
                </property>
                <property name="sizeType">
-                <enum>QSizePolicy::MinimumExpanding</enum>
+                <enum>QSizePolicy::Policy::MinimumExpanding</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
@@ -645,7 +740,7 @@
            <item row="10" column="0" colspan="2">
             <spacer name="verticalSpacer_6">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -681,7 +776,7 @@
        <item>
         <widget class="QScrollArea" name="scrollArea1">
          <property name="frameShape">
-          <enum>QFrame::NoFrame</enum>
+          <enum>QFrame::Shape::NoFrame</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
@@ -691,15 +786,15 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>347</width>
-            <height>530</height>
+            <width>330</width>
+            <height>593</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="2" column="0">
             <spacer name="verticalSpacer_2">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -891,7 +986,7 @@
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Which behavior to emulate. Note that this does not have to match your operating system.&lt;/p&gt;&lt;p&gt;If you are not sure, use the &lt;span style=&quot; font-weight:600;&quot;&gt;default&lt;/span&gt; emulation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="textFormat">
-                 <enum>Qt::RichText</enum>
+                 <enum>Qt::TextFormat::RichText</enum>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
@@ -923,10 +1018,10 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
           <bool>true</bool>
          </property>
          <property name="verticalScrollMode">
-          <enum>QAbstractItemView::ScrollPerPixel</enum>
+          <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
          </property>
          <property name="horizontalScrollMode">
-          <enum>QAbstractItemView::ScrollPerPixel</enum>
+          <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
          </property>
          <property name="sortingEnabled">
           <bool>true</bool>
@@ -982,7 +1077,7 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
           <item>
            <layout class="QFormLayout" name="formLayout">
             <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::ExpandingFieldsGrow</enum>
+             <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
             </property>
             <item row="0" column="0">
              <widget class="QLabel" name="dropHeightLabel">
@@ -1047,7 +1142,7 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
        <item>
         <spacer name="verticalSpacer_5">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -1117,7 +1212,7 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
              </font>
             </property>
             <property name="lineWrapMode">
-             <enum>QPlainTextEdit::NoWrap</enum>
+             <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
             </property>
            </widget>
           </item>
@@ -1131,10 +1226,10 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
    <item row="1" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Apply|QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
@@ -1219,6 +1314,86 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
     <hint type="destinationlabel">
      <x>640</x>
      <y>77</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>nightSchema</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>nightSchemaCombo</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>351</x>
+     <y>91</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>446</x>
+     <y>120</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>nightSchema</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>label_4</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>351</x>
+     <y>91</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>496</x>
+     <y>91</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>nightSchema</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>nightSchemaStart</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>351</x>
+     <y>91</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>452</x>
+     <y>90</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>nightSchema</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>nightSchemaEnd</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>351</x>
+     <y>91</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>540</x>
+     <y>90</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>nightSchema</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>configNightSchema</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>352</x>
+     <y>94</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>725</x>
+     <y>125</y>
     </hint>
    </hints>
   </connection>

--- a/src/palettedialog.cpp
+++ b/src/palettedialog.cpp
@@ -1,0 +1,107 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Thomas Lübking                                  *
+ *   thomas.luebking@gmail.com                                             *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#include <QDebug>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QColorDialog>
+#include <QMimeData>
+
+#include "palettedialog.h"
+
+PaletteDialog::PaletteDialog(QWidget *parent) : QDialog(parent)
+{
+    setupUi(this);
+    QColorDialog *cd = new QColorDialog(this);
+    cd->hide();
+    connect (colorbutton, SIGNAL(clicked()), cd, SLOT(show()));
+    connect (colorbutton, SIGNAL(clicked()), cd, SLOT(raise()));
+    QList<QLabel*> tileLabels = tiles->findChildren<QLabel*>();
+    for (QLabel *l : tileLabels)
+        l->installEventFilter(this);
+}
+
+void PaletteDialog::setColorSchemeName(QString name)
+{
+    nameLabel->setText(name);
+}
+
+#define IS_BACKGROUND objectName().contains(QLatin1String("Background"))
+#define IS_INTENSE objectName().contains(QLatin1String("Intense"))
+
+QMap<QString, QColor> PaletteDialog::colors()
+{
+    QMap<QString, QColor> map;
+    QList<QLabel*> tileLabels = tiles->findChildren<QLabel*>();
+    for (QLabel *l : tileLabels)
+        map[l->objectName()] = l->palette().color(l->IS_BACKGROUND ? l->backgroundRole() : l->foregroundRole());
+    return map;
+}
+
+int PaletteDialog::setColors(QMap<QString, QColor> map)
+{
+    int match = 0;
+    for (auto i = map.cbegin(), end = map.cend(); i != end; ++i) {
+        if (QLabel *l = tiles->findChild<QLabel*>(i.key())) {
+            setColor(l, i.value());
+            ++match;
+        }
+    }
+    return match;
+}
+
+void PaletteDialog::setColor(QLabel *l, QColor c)
+{
+    if (l->IS_BACKGROUND) {
+        bool intense = l->IS_INTENSE;
+        QList<QLabel*> tileLabels = tiles->findChildren<QLabel*>();
+        for (QLabel *fl : tileLabels) {
+            if (fl->IS_INTENSE == intense) {
+                QPalette pal = fl->palette();
+                pal.setColor(fl->backgroundRole(), c);
+                fl->setPalette(pal);
+            }
+        }
+    } else {
+        QPalette pal = l->palette();
+        pal.setColor(l->foregroundRole(), c);
+        l->setPalette(pal);
+        if (l->objectName().contains(QLatin1String("Foreground"))) {
+            const QString name = QString::fromLatin1(l->IS_INTENSE ? "BackgroundIntense" : "Background");
+            if (QLabel *bl = tiles->findChild<QLabel*>(name)) // Q_ASSERT
+                bl->setPalette(pal);
+        }
+    }
+}
+
+bool PaletteDialog::eventFilter(QObject *o, QEvent *e) {
+    if (e->type() == QEvent::DragEnter) {
+        QDropEvent *de = static_cast<QDragMoveEvent*>(e);
+        de->mimeData()->hasColor() ? de->accept() : de->ignore();
+        return false;
+    }
+    if (e->type() == QEvent::Drop) {
+        QDropEvent *de = static_cast<QDropEvent*>(e);
+        if (!de->mimeData()->hasColor())
+            return false;
+        if (QLabel *l = qobject_cast<QLabel*>(o))
+            setColor(l, qvariant_cast<QColor>(de->mimeData()->colorData()));
+        return false;
+    }
+    return false;
+}

--- a/src/palettedialog.h
+++ b/src/palettedialog.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by Thomas Lübking                                  *
+ *   thomas.luebking@gmail.com                                             *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ ***************************************************************************/
+
+#ifndef PALETTEDIALOG_H
+#define PALETTEDIALOG_H
+
+#include <QDialog>
+#include <QMap>
+#include "ui_palettedialog.h"
+
+class PaletteDialog : public QDialog, Ui::PaletteDialog
+{
+    Q_OBJECT
+public:
+    PaletteDialog(QWidget *parent = nullptr);
+    void setColorSchemeName(QString name);
+    QMap<QString, QColor> colors();
+    int setColors(QMap<QString, QColor>);
+protected:
+    bool eventFilter(QObject *o, QEvent *e);
+private:
+    void setColor(QLabel *l, QColor c);
+};
+
+#endif // PALETTEDIALOG_H

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -81,6 +81,9 @@ void Properties::loadSettings()
         QApplication::setStyle(guiStyle);
 
     colorScheme = m_settings->value(QLatin1String("colorScheme"), QLatin1String("Linux")).toString();
+    nightScheme = m_settings->value(QLatin1String("nightScheme"), QLatin1String("")).toString();
+    nightStart = m_settings->value(QLatin1String("nightStart"), QTime(21,0)).toTime();
+    nightEnd = m_settings->value(QLatin1String("nightEnd"), QTime(7,0)).toTime();
 
     highlightCurrentTerminal = m_settings->value(QLatin1String("highlightCurrentTerminal"), true).toBool();
     focusOnMoueOver = m_settings->value(QLatin1String("focusOnMoueOver"), false).toBool();
@@ -188,6 +191,9 @@ void Properties::saveSettings()
 {
     m_settings->setValue(QLatin1String("guiStyle"), guiStyle);
     m_settings->setValue(QLatin1String("colorScheme"), colorScheme);
+    m_settings->setValue(QLatin1String("nightScheme"), nightScheme);
+    m_settings->setValue(QLatin1String("nightStart"), nightStart);
+    m_settings->setValue(QLatin1String("nightEnd"), nightEnd);
     m_settings->setValue(QLatin1String("highlightCurrentTerminal"), highlightCurrentTerminal);
     m_settings->setValue(QLatin1String("focusOnMoueOver"), focusOnMoueOver);
     m_settings->setValue(QLatin1String("showTerminalSizeHint"), showTerminalSizeHint);

--- a/src/properties.h
+++ b/src/properties.h
@@ -23,6 +23,7 @@
 #include <QtCore>
 #include <QFont>
 #include <QFileSystemWatcher>
+#include <QTime>
 
 typedef QString Session;
 
@@ -55,6 +56,9 @@ class Properties
         QStringList shell;
         QFont font;
         QString colorScheme;
+        QString nightScheme;
+        QTime nightStart;
+        QTime nightEnd;
         QString guiStyle;
         bool highlightCurrentTerminal;
         bool focusOnMoueOver;

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -76,6 +76,11 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         KeySequenceEdit *dropShortCutEdit;
         QPushButton *exampleBookmarksButton;
 
+        void newColorScheme(QComboBox *target);
+        void editColorScheme(QComboBox *target);
+        void importColorScheme(QComboBox *target);
+        void deleteColorScheme(QComboBox *target);
+
     private slots:
         void apply();
         void accept() override;


### PR DESCRIPTION
There're several glitches, notably because QTermWidget currently does not allow to reload/refresh its colorschemes Imports and new schemes will not even show up when restarting the preferences dialog.

The dialog should probably use the configured font and maybe even change the groupbox background.

Nighttime handling isn't implemented at all

QTerminalWidget does also not take transient schemes One could use a tmpfile to transmit a faded version, but that's not very exciting