### PR TITLE
Added option for mouse cursor auto-hiding

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -772,7 +772,33 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0" colspan="2">
+              <item row="4" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>Mouse cursor hiding delay</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QSpinBox" name="mouseAutoHideSpinBox">
+                <property name="specialValueText">
+                 <string>No hiding</string>
+                </property>
+                <property name="suffix">
+                 <string> sec</string>
+                </property>
+                <property name="minimum">
+                 <number>-1</number>
+                </property>
+                <property name="maximum">
+                 <number>60</number>
+                </property>
+                <property name="value">
+                 <number>-1</number>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0" colspan="2">
                <widget class="QCheckBox" name="disableBracketedPasteModeCheckBox">
                 <property name="toolTip">
                  <string>Bracketed paste mode is useful for pasting multiline strings.</string>
@@ -782,35 +808,35 @@
                 </property>
                </widget>
               </item>
-              <item row="5" column="0" colspan="2">
+              <item row="6" column="0" colspan="2">
                <widget class="QCheckBox" name="confirmMultilinePasteCheckBox">
                 <property name="text">
                  <string>Confirm multiline paste</string>
                 </property>
                </widget>
               </item>
-              <item row="6" column="0" colspan="2">
+              <item row="7" column="0" colspan="2">
                <widget class="QCheckBox" name="trimPastedTrailingNewlinesCheckBox">
                 <property name="text">
                  <string>Trim trailing newlines in pasted text</string>
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="2">
+              <item row="8" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
                  <string>Prompt on closing with a running process</string>
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="2">
+              <item row="9" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="0" colspan="2">
+              <item row="10" column="0" colspan="2">
                <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
                 <property name="toolTip">
                  <string>If unchecked the new tab will be opened as the rightmost tab</string>
@@ -820,21 +846,21 @@
                 </property>
                </widget>
               </item>
-              <item row="10" column="0">
+              <item row="11" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
                 </property>
                </widget>
               </item>
-              <item row="11" column="0">
+              <item row="12" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="11" column="1">
+              <item row="12" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -860,10 +886,10 @@
                 </item>
                </widget>
               </item>
-              <item row="12" column="1">
+              <item row="13" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
-              <item row="12" column="0">
+              <item row="13" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -181,6 +181,12 @@ void Properties::loadSettings()
 
     swapMouseButtons2and3 = m_settings->value(QLatin1String("SwapMouseButtons2and3"), false).toBool();
 
+    mouseAutoHideDelay = m_settings->value(QLatin1String("MouseAutoHideDelay"), -1).toInt();
+    if (mouseAutoHideDelay > 0)
+    {
+        mouseAutoHideDelay *= 1000;
+    }
+
     prefDialogSize = m_settings->value(QLatin1String("PrefDialogSize")).toSize();
 }
 
@@ -292,6 +298,17 @@ void Properties::saveSettings()
 
     m_settings->setValue(QLatin1String("LastWindowMaximized"), windowMaximized);
     m_settings->setValue(QLatin1String("SwapMouseButtons2and3"), swapMouseButtons2and3);
+
+    int autoDelay = mouseAutoHideDelay;
+    if (autoDelay > 0)
+    {
+        autoDelay /= 1000;
+    }
+    else if (autoDelay < 0)
+    {
+        autoDelay = -1;
+    }
+    m_settings->setValue(QLatin1String("MouseAutoHideDelay"), autoDelay);
 
     m_settings->setValue(QLatin1String("PrefDialogSize"), prefDialogSize);
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -128,6 +128,7 @@ class Properties
 
         bool windowMaximized;
         bool swapMouseButtons2and3;
+        int mouseAutoHideDelay;
 
         bool useFontBoxDrawingChars;
     private:

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -207,6 +207,17 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     // word characters for text selection
     wordCharactersLineEdit->setText(Properties::Instance()->wordCharacters);
 
+    int autoDelay = Properties::Instance()->mouseAutoHideDelay;
+    if (autoDelay > 0)
+    {
+        autoDelay /= 1000;
+    }
+    else if (autoDelay < 0)
+    {
+        autoDelay = -1;
+    }
+    mouseAutoHideSpinBox->setValue(autoDelay);
+
     // Setting windows style actions
     styleComboBox->addItem(tr("System Default"));
     styleComboBox->addItems(QStyleFactory::keys());
@@ -395,6 +406,13 @@ void PropertiesDialog::apply()
     Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
     Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();
     Properties::Instance()->wordCharacters = wordCharactersLineEdit->text();
+
+    int autoDelay = mouseAutoHideSpinBox->value();
+    if (autoDelay > 0)
+    {
+        autoDelay *= 1000;
+    }
+    Properties::Instance()->mouseAutoHideDelay = autoDelay;
 
     saveBookmarksFile();
     // NOTE: Because the path of the bookmarks file may be changed by saveBookmarksFile(),

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -114,6 +114,7 @@ void TermWidgetImpl::propertiesChanged()
     disableBracketedPasteMode(Properties::Instance()->m_disableBracketedPasteMode);
     setConfirmMultilinePaste(Properties::Instance()->confirmMultilinePaste);
     setWordCharacters(Properties::Instance()->wordCharacters);
+    autoHideMouseAfter(Properties::Instance()->mouseAutoHideDelay);
     setTrimPastedTrailingNewlines(Properties::Instance()->trimPastedTrailingNewlines);
     setTerminalSizeHint(Properties::Instance()->showTerminalSizeHint);
 


### PR DESCRIPTION
This patch needs https://github.com/lxqt/qtermwidget/pull/582.

The new option is in Preferences → Behavior. It can be from "No hiding" to 60 seconds. A value of zero hides the cursor immediately (as designed by @luebking).

Closes https://github.com/lxqt/qterminal/issues/403