### PR TITLE
Don't allow zero timeout for mouse cursor auto-hiding

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -795,13 +795,13 @@
                  <string> sec</string>
                 </property>
                 <property name="minimum">
-                 <number>-1</number>
+                 <number>0</number>
                 </property>
                 <property name="maximum">
                  <number>60</number>
                 </property>
                 <property name="value">
-                 <number>-1</number>
+                 <number>0</number>
                 </property>
                </widget>
               </item>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -187,6 +187,10 @@ void Properties::loadSettings()
     {
         mouseAutoHideDelay *= 1000;
     }
+    else
+    {
+        mouseAutoHideDelay = -1; // disable (no zero delay)
+    }
 
     prefDialogSize = m_settings->value(QLatin1String("PrefDialogSize")).toSize();
 }
@@ -306,9 +310,9 @@ void Properties::saveSettings()
     {
         autoDelay /= 1000;
     }
-    else if (autoDelay < 0)
+    else
     {
-        autoDelay = -1;
+        autoDelay = 0; // means disabling when saved
     }
     m_settings->setValue(QLatin1String("MouseAutoHideDelay"), autoDelay);
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -216,10 +216,6 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     {
         autoDelay /= 1000;
     }
-    else if (autoDelay < 0)
-    {
-        autoDelay = -1;
-    }
     mouseAutoHideSpinBox->setValue(autoDelay);
 
     // Setting windows style actions
@@ -416,6 +412,10 @@ void PropertiesDialog::apply()
     if (autoDelay > 0)
     {
         autoDelay *= 1000;
+    }
+    else
+    {
+        autoDelay = -1; // disable (no zero delay)
     }
     Properties::Instance()->mouseAutoHideDelay = autoDelay;
 


### PR DESCRIPTION
Although it is (and should be) allowed in `qtermwidget`, it has no use in QTerminal and can be confusing to users.