### PR TITLE
Removed a wrong style sheet from dropdown mode

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -50,9 +50,6 @@
 typedef std::function<bool(MainWindow&, QAction *)> checkfn;
 Q_DECLARE_METATYPE(checkfn)
 
-// TODO/FXIME: probably remove. QSS makes it unusable on mac...
-#define QSS_DROP    "MainWindow {border: 1px solid rgba(0, 0, 0, 50%);}\n"
-
 MainWindow::MainWindow(TerminalConfig &cfg,
                        bool dropMode,
                        QWidget * parent,
@@ -112,7 +109,6 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setContentsMargins(0, 0, 0, 0);
     if (m_dropMode) {
         this->enableDropMode();
-        setStyleSheet(QStringLiteral(QSS_DROP));
     }
     else {
         if (Properties::Instance()->saveSizeOnExit) {


### PR DESCRIPTION
Style sheets should never be applied in that way because, otherwise, they'll badly interfere with `QStyle`.

Only by chance, I saw the problem in combo-boxes of the dropdown preferences dialog with Kvantum; styles like Fusion and Breeze don't reveal such issues clearly (but, as the old code comment said, macOS was also unhappy about it).