### PR TITLE
Draw a border around font dialog on Wayland

### DIFF
--- a/src/fontdialog.cpp
+++ b/src/fontdialog.cpp
@@ -17,9 +17,11 @@
  ***************************************************************************/
 
 #include "fontdialog.h"
+#include <QPaintEvent>
+#include <QPainter>
 
 FontDialog::FontDialog(const QFont &f, QWidget *parent)
-    : QDialog(parent)
+    : QDialog(parent), mDrawBorder(false)
 {
     setupUi(this);
 
@@ -60,4 +62,36 @@ void FontDialog::setFontSize()
     previewLabel->setFont(f);
     QString sample(QLatin1String("%1 %2 pt"));
     previewLabel->setText(sample.arg(f.family()).arg(f.pointSize()));
+}
+
+void FontDialog::drawBorder()
+{
+    if (!mDrawBorder)
+    {
+        mDrawBorder = true;
+        QMargins m = contentsMargins();
+        setContentsMargins(m.left() + 1, 0, m.right() + 1, m.bottom() + 1);
+    }
+}
+
+void FontDialog::paintEvent(QPaintEvent *event)
+{
+    QDialog::paintEvent(event);
+
+    if (mDrawBorder)
+    {
+        QPainter painter(this);
+        painter.save();
+        painter.setClipRegion(rect());
+        QColor color = palette().color(QPalette::Highlight);
+        color.setAlpha(180);
+        QPen pen(color);
+        pen.setWidth(1);
+        painter.setPen(pen);
+        painter.drawLine(rect().topLeft(), rect().bottomLeft());
+        painter.drawLine(rect().bottomLeft() + QPoint(1 , 0), rect().bottomRight() + QPoint(-1 , 0));
+        painter.drawLine(rect().topRight(), rect().bottomRight());
+        painter.restore();
+        painter.end();
+    }
 }

--- a/src/fontdialog.h
+++ b/src/fontdialog.h
@@ -30,11 +30,17 @@ class FontDialog : public QDialog, public Ui::FontDialog
 public:
     FontDialog(const QFont &f, QWidget *parent = nullptr);
     QFont getFont();
+    void drawBorder();
+
+protected:
+    void paintEvent(QPaintEvent *event);
 
 private slots:
     void setFontSample(const QFont &f);
     void setFontSize();
 
+private:
+    bool mDrawBorder;
 };
 
 #endif

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -719,31 +719,38 @@ bool PropertiesDialog::event(QEvent *event)
     {
         if (auto layershell = LayerShellQt::Window::get(windowHandle()))
         {
-            if (event->type() == QEvent::WindowBlocked
-                && layershell->layer() == LayerShellQt::Window::Layer::LayerOverlay)
+            LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop};
+            if (layershell->anchors() == anchors)
             {
-                if (auto dialog = qobject_cast<QDialog*>(qApp->activeModalWidget()))
+                if (event->type() == QEvent::WindowBlocked
+                    && layershell->layer() == LayerShellQt::Window::Layer::LayerOverlay)
                 {
-                    dialog->winId();
-                    if (QWindow *win = dialog->windowHandle())
+                    if (auto dialog = qobject_cast<QDialog*>(qApp->activeModalWidget()))
                     {
-                        if (auto dlgLayershell = LayerShellQt::Window::get(win))
+                        dialog->winId();
+                        if (QWindow *win = dialog->windowHandle())
                         {
-                            dlgLayershell->setLayer(LayerShellQt::Window::Layer::LayerOverlay);
-                            dlgLayershell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
-                            LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop};
-                            dlgLayershell->setAnchors(anchors);
-                            dlgLayershell->setScreenConfiguration(LayerShellQt::Window::ScreenConfiguration::ScreenFromCompositor);
-
-                            layershell->setLayer(LayerShellQt::Window::Layer::LayerTop);
+                            if (auto dlgLayershell = LayerShellQt::Window::get(win))
+                            {
+                                dlgLayershell->setLayer(LayerShellQt::Window::Layer::LayerOverlay);
+                                dlgLayershell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivityOnDemand);
+                                LayerShellQt::Window::Anchors anchors = {LayerShellQt::Window::AnchorTop};
+                                dlgLayershell->setAnchors(anchors);
+                                dlgLayershell->setScreenConfiguration(LayerShellQt::Window::ScreenConfiguration::ScreenFromCompositor);
+                                if (auto fontDialog = qobject_cast<FontDialog*>(dialog))
+                                {
+                                    fontDialog->drawBorder();
+                                }
+                                layershell->setLayer(LayerShellQt::Window::Layer::LayerTop);
+                            }
                         }
                     }
                 }
-            }
-            else if (event->type() == QEvent::WindowUnblocked
-                     && layershell->layer() == LayerShellQt::Window::Layer::LayerTop)
-            {
-                layershell->setLayer(LayerShellQt::Window::Layer::LayerOverlay);
+                else if (event->type() == QEvent::WindowUnblocked
+                         && layershell->layer() == LayerShellQt::Window::Layer::LayerTop)
+                {
+                    layershell->setLayer(LayerShellQt::Window::Layer::LayerOverlay);
+                }
             }
         }
     }


### PR DESCRIPTION
… because it's on the overlay layer and so, borderless.

Also fixed a problem in the previous commit about setting the font dialog on the overlay layer.