### PR TITLE
Add workaround for bug in reactivating dropdown in certain X11 WMs

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -831,6 +831,7 @@ void MainWindow::showHide()
         }
         realign();
         show();
+        setWindowState(windowState() & ~Qt::WindowMinimized);
         activateWindow();
     }
 }


### PR DESCRIPTION
Adds a workaround for WMs who sometimes activate QTerminal dropdown in a minimized state

"Certain X11 WMs" being namely Xfwm4 and Openbox

To reproduce: https://github.com/lxqt/qterminal/issues/1066

----

Adding `raise();` did not suffice. This patch explicitly sets window state to not minimized when shown.