### PR TITLE
Made the dropdown window a tool window under X11

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -190,6 +190,10 @@ void MainWindow::enableDropMode()
     }
 
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
+    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+    { // some X11 WMs may need this
+        setWindowFlags(windowFlags() | Qt::Popup);
+    }
 
     m_dropLockButton = new QToolButton(this);
     m_dropLockButton->setToolTip(tr("Keep window open when it loses focus"));


### PR DESCRIPTION
… by adding `Qt::Popup` to the `Qt::Dialog` flag. The reason is that some X11 WMs may need it to hide the task button.

NOTE: This needs thorough tests under well-known X11 WMs that are being developed, especially by showing the properties dialog its sub-dialogs like the font dialog and LXQt file dialog, as well as the pasting and exiting prompt dialogs.