### PR TITLE
Set the dropdown minimum size to 25%

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -1032,6 +1032,12 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
               <property name="suffix">
                <string>%</string>
               </property>
+              <property name="minimum">
+               <number>25</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
@@ -1048,6 +1054,12 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
              <widget class="QSpinBox" name="dropWidthSpinBox">
               <property name="suffix">
                <string>%</string>
+              </property>
+              <property name="minimum">
+               <number>25</number>
+              </property>
+              <property name="maximum">
+               <number>100</number>
               </property>
              </widget>
             </item>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -165,8 +165,8 @@ void Properties::loadSettings()
     dropShortCut = QKeySequence(m_settings->value(QLatin1String("ShortCut"), QLatin1String("F12")).toString());
     dropKeepOpen = m_settings->value(QLatin1String("KeepOpen"), false).toBool();
     dropShowOnStart = m_settings->value(QLatin1String("ShowOnStart"), true).toBool();
-    dropWidth = m_settings->value(QLatin1String("Width"), 70).toInt();
-    dropHeight = m_settings->value(QLatin1String("Height"), 45).toInt();
+    dropWidth = qBound(25, m_settings->value(QLatin1String("Width"), 70).toInt(), 100);
+    dropHeight = qBound(25, m_settings->value(QLatin1String("Height"), 45).toInt(), 100);
     m_settings->endGroup();
 
     changeWindowTitle = m_settings->value(QLatin1String("ChangeWindowTitle"), true).toBool();

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -268,8 +268,6 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropShowOnStartCheckBox->setChecked(Properties::Instance()->dropShowOnStart);
     dropKeepOpenCheckBox->setChecked(Properties::Instance()->dropKeepOpen);
 
-    dropHeightSpinBox->setMaximum(100);
-    dropWidthSpinBox->setMaximum(100);
     dropHeightSpinBox->setValue(Properties::Instance()->dropHeight);
     dropWidthSpinBox->setValue(Properties::Instance()->dropWidth);
 


### PR DESCRIPTION
This is especially needed on Wayland because of a Qt bug that lets Qt windows become tiny. But it's good for X11 too.