### PR TITLE
Give better title to drop-down desktop file

### DIFF
--- a/src/translations/qterminal-drop.desktop.yaml
+++ b/src/translations/qterminal-drop.desktop.yaml
@@ -1,3 +1,3 @@
-Desktop Entry/Name: "QTerminal drop down"
+Desktop Entry/Name: "QTerminal Drop-down"
 Desktop Entry/GenericName: "Drop-down Terminal"
 Desktop Entry/Comment: "A drop-down terminal emulator"

--- a/src/translations/qterminal-drop_en_GB.desktop.yaml
+++ b/src/translations/qterminal-drop_en_GB.desktop.yaml
@@ -1,3 +1,3 @@
-Desktop Entry/Name: "QTerminal drop down"
+Desktop Entry/Name: "QTerminal Drop-down"
 Desktop Entry/GenericName: "Drop-down Terminal"
 Desktop Entry/Comment: "A drop-down terminal emulator"

--- a/src/translations/qterminal.desktop.yaml
+++ b/src/translations/qterminal.desktop.yaml
@@ -1,4 +1,4 @@
 Desktop Entry/Name: "QTerminal"
 Desktop Entry/GenericName: "Terminal emulator"
 Desktop Entry/Comment: "Terminal emulator"
-Desktop Action Dropdown/Name: "Drop-down terminal"
+Desktop Action Dropdown/Name: "Drop-down Terminal"


### PR DESCRIPTION
Change title, "QTerminal drop down" → "QTerminal Drop-down".

Translations are again questionable. I'm guessing many languages will already be correct as they have their own word for "dropdown".