### PR TITLE
Ignore presets (subterminal creation) with `-e` option

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,6 +116,13 @@ void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_co
         }
     }
     while(next_option != -1);
+
+    // FIXME: The app might not exit in the dropdown mode after the shell command is terminated
+    // and the window is closed. For now, the dropdown mode is disabled with command execution.
+    if (!shell_command.isEmpty())
+    {
+        dropMode = false;
+    }
 }
 
 int main(int argc, char *argv[])

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -996,6 +996,13 @@ void MainWindow::bookmarksDock_visibilityChanged(bool visible)
 
 void MainWindow::addNewTab(TerminalConfig cfg)
 {
+    if (cfg.hasCommand())
+    {
+        // do not create subterminals if there is a command (-e option)
+        consoleTabulator->addNewTab(cfg);
+        return;
+    }
+
     if (Properties::Instance()->terminalsPreset == 3)
         consoleTabulator->preset4Terminals();
     else if (Properties::Instance()->terminalsPreset == 2)


### PR DESCRIPTION
Also, the dropdown mode had a conflict with the `-e` option. As a workaround, `-d` is also ignored in a command like `qterminal -d -e <COMMAND>`.

Closes https://github.com/lxqt/qterminal/issues/1243