### PR TITLE
Rename dropdown for desktop files

### DIFF
--- a/src/translations/qterminal-drop.desktop.yaml
+++ b/src/translations/qterminal-drop.desktop.yaml
@@ -1,3 +1,3 @@
-Desktop Entry/Name: "QTerminal Drop-down"
-Desktop Entry/GenericName: "Drop-down Terminal"
-Desktop Entry/Comment: "A drop-down terminal emulator"
+Desktop Entry/Name: "QTerminal Dropdown"
+Desktop Entry/GenericName: "Dropdown Terminal"
+Desktop Entry/Comment: "A dropdown terminal emulator"

--- a/src/translations/qterminal-drop_en_GB.desktop.yaml
+++ b/src/translations/qterminal-drop_en_GB.desktop.yaml
@@ -1,3 +1,3 @@
-Desktop Entry/Name: "QTerminal Drop-down"
-Desktop Entry/GenericName: "Drop-down Terminal"
-Desktop Entry/Comment: "A drop-down terminal emulator"
+Desktop Entry/Name: "QTerminal Dropdown"
+Desktop Entry/GenericName: "Dropdown Terminal"
+Desktop Entry/Comment: "A dropdown terminal emulator"

--- a/src/translations/qterminal.desktop.yaml
+++ b/src/translations/qterminal.desktop.yaml
@@ -1,4 +1,4 @@
 Desktop Entry/Name: "QTerminal"
 Desktop Entry/GenericName: "Terminal emulator"
 Desktop Entry/Comment: "Terminal emulator"
-Desktop Action Dropdown/Name: "Drop-down Terminal"
+Desktop Action Dropdown/Name: "Dropdown Terminal"

--- a/src/translations/qterminal_en_GB.desktop.yaml
+++ b/src/translations/qterminal_en_GB.desktop.yaml
@@ -1,4 +1,4 @@
 Desktop Entry/Name: "QTerminal"
 Desktop Entry/GenericName: "Terminal emulator"
 Desktop Entry/Comment: "Terminal emulator"
-Desktop Action Dropdown/Name: "Drop-down Terminal"
+Desktop Action Dropdown/Name: "Dropdown Terminal"


### PR DESCRIPTION
Not sure why I chose `Drop-down` previously.

`Dropdown` is a standard word in English for user interfaces.