### PR TITLE
Fixed exiting drop-down terminal on X11

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -190,10 +190,6 @@ void MainWindow::enableDropMode()
     }
 
     setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
-    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
-    { // some X11 WMs may need this
-        setWindowFlags(windowFlags() | Qt::Popup);
-    }
 
     m_dropLockButton = new QToolButton(this);
     m_dropLockButton->setToolTip(tr("Keep window open when it loses focus"));


### PR DESCRIPTION
The WM workaround for X11 was the culprit. That workaround had another serious issue too: the drop-down terminal didn't get the focus on showing.

Fixes https://github.com/lxqt/qterminal/issues/1260

The moral of the story: *Never try to hide others' bugs in a sensitive app.*