### PR TITLE
Add option for saving window state

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -592,6 +592,13 @@
             </widget>
            </item>
            <item row="9" column="0" colspan="2">
+            <widget class="QCheckBox" name="saveStateOnExitCheckBox">
+             <property name="text">
+              <string>Save State when closing</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0" colspan="2">
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <property name="spacing">
               <number>5</number>
@@ -649,7 +656,7 @@
              </item>
             </layout>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="11" column="0" colspan="2">
             <spacer name="verticalSpacer_6">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -123,7 +123,9 @@ MainWindow::MainWindow(TerminalConfig &cfg,
             ) {
             move(Properties::Instance()->mainWindowPosition);
         }
-        restoreState(Properties::Instance()->mainWindowState);
+        if (Properties::Instance()->saveStateOnExit) {
+            restoreState(Properties::Instance()->mainWindowState);
+        }
     }
 
     consoleTabulator->setAutoFillBackground(true);
@@ -664,7 +666,9 @@ void MainWindow::closeEvent(QCloseEvent *ev)
                 Properties::Instance()->mainWindowSize = size();
             }
             Properties::Instance()->windowMaximized = isMaximized();
-            Properties::Instance()->mainWindowState = saveState();
+            if (Properties::Instance()->saveStateOnExit) {
+                Properties::Instance()->mainWindowState = saveState();
+            }
         }
         rebuildActions(); // shortcuts may have changed by another running instance
         Properties::Instance()->saveSettings();

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -147,6 +147,7 @@ void Properties::loadSettings()
     askOnExit = m_settings->value(QLatin1String("AskOnExit"), true).toBool();
     saveSizeOnExit = m_settings->value(QLatin1String("SaveSizeOnExit"), true).toBool();
     savePosOnExit = m_settings->value(QLatin1String("SavePosOnExit"), true).toBool();
+    saveStateOnExit = m_settings->value(QLatin1String("SaveStateOnExit"), true).toBool();
     useCWD = m_settings->value(QLatin1String("UseCWD"), true).toBool();
     m_openNewTabRightToActiveTab = m_settings->value(QLatin1String("OpenNewTabRightToActiveTab"), false).toBool();
     audibleBell = m_settings->value(QLatin1String("AudibleBell"), false).toBool();
@@ -272,6 +273,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("AskOnExit"), askOnExit);
     m_settings->setValue(QLatin1String("SavePosOnExit"), savePosOnExit);
     m_settings->setValue(QLatin1String("SaveSizeOnExit"), saveSizeOnExit);
+    m_settings->setValue(QLatin1String("SaveStateOnExit"), saveStateOnExit);
     m_settings->setValue(QLatin1String("UseCWD"), useCWD);
     m_settings->setValue(QLatin1String("OpenNewTabRightToActiveTab"), m_openNewTabRightToActiveTab);
     m_settings->setValue(QLatin1String("AudibleBell"), audibleBell);

--- a/src/properties.h
+++ b/src/properties.h
@@ -98,6 +98,7 @@ class Properties
 
         bool saveSizeOnExit;
         bool savePosOnExit;
+        bool saveStateOnExit;
 
         bool useCWD;
         bool m_openNewTabRightToActiveTab;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -245,6 +245,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     savePosOnExitCheckBox->setChecked(Properties::Instance()->savePosOnExit);
     saveSizeOnExitCheckBox->setChecked(Properties::Instance()->saveSizeOnExit);
+    saveStateOnExitCheckBox->setChecked(Properties::Instance()->saveStateOnExit);
     fixedWithSpinBox->setValue(Properties::Instance()->fixedWindowSize.width());
     fixedHeightSpinBox->setValue(Properties::Instance()->fixedWindowSize.height());
 
@@ -355,6 +356,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->savePosOnExit = savePosOnExitCheckBox->isChecked();
     Properties::Instance()->saveSizeOnExit = saveSizeOnExitCheckBox->isChecked();
+    Properties::Instance()->saveStateOnExit = saveStateOnExitCheckBox->isChecked();
     Properties::Instance()->fixedWindowSize = QSize(fixedWithSpinBox->value(), fixedHeightSpinBox->value()).expandedTo(QSize(300, 200)); // FIXME: make Properties variables private and use public methods for setting/getting them
     Properties::Instance()->prefDialogSize = size();
 


### PR DESCRIPTION
Adds a checkbox option in Preferences -> Window. When unchecked, the window's state will not be saved to the settings file.

This is useful when the settings file is managed with version control.