### PR TITLE
Added bookmarks action to view context menu

### DIFF
--- a/src/forms/qterminal.ui
+++ b/src/forms/qterminal.ui
@@ -54,6 +54,9 @@
      <height>26</height>
     </rect>
    </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::PreventContextMenu</enum>
+   </property>
    <widget class="QMenu" name="menu_File">
     <property name="title">
      <string>&amp;Session</string>

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -203,6 +203,7 @@ void TermWidgetImpl::customContextMenuCall(const QPoint & pos)
     menu.addAction(actions[QStringLiteral(SUB_COLLAPSE)]);
     menu.addSeparator();
     menu.addAction(actions[QStringLiteral(TOGGLE_MENU)]);
+    menu.addAction(actions[QStringLiteral(TOGGLE_BOOKMARKS)]);
     menu.addAction(actions[QStringLiteral(HIDE_WINDOW_BORDERS)]);
     menu.addAction(actions[QStringLiteral(PREFERENCES)]);
 


### PR DESCRIPTION
… and removed the menubar context menu.

The reason is that the menubar context menu had a single item that showed bookmarks *regardless of Preferences*. It was possible to control it, but that would require extra codes for something useless when toggling bookmarks can be added to the view context menu.

Closes https://github.com/lxqt/qterminal/issues/1274