### PR TITLE
Silenced Clang warnings

### DIFF
--- a/src/third-party/qxtglobalshortcut_p.h
+++ b/src/third-party/qxtglobalshortcut_p.h
@@ -58,7 +58,7 @@ public:
     static bool error;
 #ifndef Q_OS_MAC
     static int ref;
-    bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result);
+    bool nativeEventFilter(const QByteArray &eventType, void *message, qintptr *result) override;
 #endif
 
     static void activateShortcut(quint32 nativeKey, quint32 nativeMods);


### PR DESCRIPTION
Closes https://github.com/lxqt/qterminal/issues/1284

NOTE: The appearance of the patch is so only because this old file was saved with MS Windows newlines! The code change is only the addition of `override`.