### PR TITLE
Support shortcut for lock button of dropdown mode

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -1073,6 +1073,33 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
         </widget>
        </item>
        <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Policy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="lockShortCutFormLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="lockShortCutLabel">
+           <property name="text">
+            <string>Lock shortcut:</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_5">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -202,6 +202,7 @@ void MainWindow::enableDropMode()
     m_dropLockButton->setAutoRaise(true);
 
     setDropShortcut(Properties::Instance()->dropShortCut);
+    setDropLockShortCut(Properties::Instance()->dropLockShortCut);
     realign();
 }
 
@@ -214,6 +215,14 @@ void MainWindow::setDropShortcut(const QKeySequence& dropShortCut)
     {
         m_dropShortcut.setShortcut(dropShortCut);
         qWarning().noquote() << tr("Press \"%1\" to see the terminal.").arg(dropShortCut.toString());
+    }
+}
+
+void MainWindow::setDropLockShortCut(const QKeySequence& dropLockShortCut)
+{
+    if (m_dropLockButton)
+    {
+        m_dropLockButton->setShortcut(dropLockShortCut);
     }
 }
 
@@ -713,6 +722,7 @@ void MainWindow::propertiesChanged()
     consoleTabulator->setTabPosition((QTabWidget::TabPosition)Properties::Instance()->tabsPos);
     consoleTabulator->propertiesChanged();
     setDropShortcut(Properties::Instance()->dropShortCut);
+    setDropLockShortCut(Properties::Instance()->dropLockShortCut);
 
 
     const auto menuBarActions = m_menuBar->actions();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -96,6 +96,7 @@ private:
     QxtGlobalShortcut m_dropShortcut;
     void realign();
     void setDropShortcut(const QKeySequence& dropShortCut);
+    void setDropLockShortCut(const QKeySequence& dropLockShortCut);
 
     bool hasMultipleTabs(QAction *);
     bool hasMultipleSubterminals(QAction *);

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -165,6 +165,7 @@ void Properties::loadSettings()
 
     m_settings->beginGroup(QLatin1String("DropMode"));
     dropShortCut = QKeySequence(m_settings->value(QLatin1String("ShortCut"), QLatin1String("F12")).toString());
+    dropLockShortCut = QKeySequence(m_settings->value(QLatin1String("KeepOpenShortCut")).toString());
     dropKeepOpen = m_settings->value(QLatin1String("KeepOpen"), false).toBool();
     dropShowOnStart = m_settings->value(QLatin1String("ShowOnStart"), true).toBool();
     dropWidth = qBound(25, m_settings->value(QLatin1String("Width"), 70).toInt(), 100);
@@ -290,6 +291,7 @@ void Properties::saveSettings()
 
     m_settings->beginGroup(QLatin1String("DropMode"));
     m_settings->setValue(QLatin1String("ShortCut"), dropShortCut.toString());
+    m_settings->setValue(QLatin1String("KeepOpenShortCut"), dropLockShortCut.toString());
     m_settings->setValue(QLatin1String("KeepOpen"), dropKeepOpen);
     m_settings->setValue(QLatin1String("ShowOnStart"), dropShowOnStart);
     m_settings->setValue(QLatin1String("Width"), dropWidth);

--- a/src/properties.h
+++ b/src/properties.h
@@ -117,6 +117,7 @@ class Properties
         int terminalsPreset;
 
         QKeySequence dropShortCut;
+        QKeySequence dropLockShortCut;
         bool dropKeepOpen;
         bool dropShowOnStart;
         int dropWidth;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -277,6 +277,11 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropShortCutEdit->installEventFilter(this);
     dropShortCutEdit->setKeySequence(Properties::Instance()->dropShortCut);
 
+    lockShortCutEdit = new KeySequenceEdit();
+    lockShortCutFormLayout->setWidget(0, QFormLayout::FieldRole, lockShortCutEdit);
+    lockShortCutEdit->installEventFilter(this);
+    lockShortCutEdit->setKeySequence(Properties::Instance()->dropLockShortCut);
+
     useBookmarksCheckBox->setChecked(Properties::Instance()->useBookmarks);
     bookmarksLineEdit->setText(Properties::Instance()->bookmarksFile); // also needed by openBookmarksFile()
     connect(bookmarksLineEdit, &QLineEdit::editingFinished,
@@ -397,6 +402,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->dropHeight = dropHeightSpinBox->value();
     Properties::Instance()->dropWidth = dropWidthSpinBox->value();
     Properties::Instance()->dropShortCut = dropShortCutEdit->keySequence();
+    Properties::Instance()->dropLockShortCut = lockShortCutEdit->keySequence();
 
     Properties::Instance()->useBookmarks = useBookmarksCheckBox->isChecked();
 
@@ -683,13 +689,18 @@ void PropertiesDialog::saveBookmarksFile()
 
 bool PropertiesDialog::eventFilter(QObject *object, QEvent *event)
 {
-    if (object == dropShortCutEdit) {
+    if (object == dropShortCutEdit || object == lockShortCutEdit) {
         if (event->type() == QEvent::KeyPress) {
             QKeyEvent *ke = static_cast<QKeyEvent *>(event);
             int k = ke->key();
             // treat Tab and Backtab like other keys (instead of changing focus)
             if (k == Qt::Key_Tab || k ==  Qt::Key_Backtab) {
-                dropShortCutEdit->pressKey(ke);
+                if (object == dropShortCutEdit) {
+                    dropShortCutEdit->pressKey(ke);
+                }
+                else {
+                    lockShortCutEdit->pressKey(ke);
+                }
                 return true;
             }
             // apply with Enter/Return and cancel with Escape, like in other entries

--- a/src/propertiesdialog.h
+++ b/src/propertiesdialog.h
@@ -74,6 +74,7 @@ class PropertiesDialog : public QDialog, Ui::PropertiesDialog
         void saveBookmarksFile();
 
         KeySequenceEdit *dropShortCutEdit;
+        KeySequenceEdit *lockShortCutEdit;
         QPushButton *exampleBookmarksButton;
 
     private slots:


### PR DESCRIPTION
It can be added in Preferences → Dropdown.

Closes https://github.com/lxqt/qterminal/issues/1290