### PR TITLE
Remediates lower-case “version” in `bug_report.md`'s “QTerminal Version”.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -41,7 +41,7 @@ assignees: ''
 ##### System Information
 <!--- Include as many relevant details about the system you experienced    --->
 <!--- the bug in                                                           --->
-* QTerminal version:
+* QTerminal Version:
 * Distribution & Version:
 * Kernel:
 * Qt Version:


### PR DESCRIPTION
It should be title case, as all else are.