### PR TITLE
Make `feature_request.md`'s headings consistent.

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,16 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+##### Relevant Problems
 <!-- A clear and concise description of what the problem is.                -->
 <!-- Example: I'm always frustrated when [...]                              -->
 
-**Describe the solution you'd like**
+##### The Solution You'd Like
 <!-- A clear and concise description of what you want to happen, tell us    -->
 <!-- how it should work, explain the difference from current behavior.      -->
 <!-- A screenshot might help.                                               -->
 
-**Describe eventual alternatives you've considered**
+##### Eventual Alternatives You've Considered
 <!-- A clear and concise description of any alternative solutions or        -->
 <!-- features you've considered.                                            -->
 


### PR DESCRIPTION
Previously, solely “Context” was an `h5`, whereas the others were phrased as sentences, bolded.

#### My Rationale

The `h5` should, at least, be an `h4`, since GitHub's CSS3 defines `h4, p { font-size: 1em }`, but `h5` is < `1em`. However, in lieu of that, I've at least made the headings consistent with `bug_report.md`, whose are `h5`s, in title case.