### PR TITLE
Guard `titleChanged` to prevent tab names from being overwritten by session attribute changes

### DIFF
--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -321,7 +321,16 @@ TermWidget::TermWidget(TerminalConfig &cfg, QWidget *parent)
     connect(m_term, &QTermWidget::finished, this, &TermWidget::finished);
     connect(m_term, &QTermWidget::termGetFocus, this, &TermWidget::term_termGetFocus);
     connect(m_term, &QTermWidget::termLostFocus, this, &TermWidget::term_termLostFocus);
-    connect(m_term, &QTermWidget::titleChanged, this, [this] { emit termTitleChanged(m_term->title(), m_term->icon()); });
+    connect(m_term, &QTermWidget::titleChanged, this, [this] {
+        // Only propagate the title if the shell has explicitly set one via an
+        // escape sequence (OSC 0/1/2). Other session-attribute changes (e.g.
+        // OSC 7 working-directory updates) also emit titleChanged, but the
+        // title itself has not been set, so propagating it would overwrite the
+        // tab label with the default "QTermWidget" name.
+        if (m_term->isTitleChanged()) {
+            emit termTitleChanged(m_term->title(), m_term->icon());
+        }
+    });
 }
 
 void TermWidget::propertiesChanged()


### PR DESCRIPTION
### Background

https://github.com/lxqt/qtermwidget/pull/611 added OSC 7 escape sequence support to qtermwidget, allowing shells to report their current working directory to the terminal emulator. This is a standard escape sequence that modern shells emit. The change moved the working directory resolution logic from `QTermWidget::workingDirectory()` into `Session::currentWorkingDirectory()` and added a new `currentDirectoryChanged` signal.

### Problem

After updating to the version of qtermwidget containing the OSC 7 commit, qterminal tabs that were previously named "Shell No. 1", "Shell No. 2", etc. are now all named "QTermWidget".

Steps to reproduce:

1. Build qtermwidget with https://github.com/lxqt/qtermwidget/pull/611 (OSC 7 support).
2. Open qterminal and open a few new tabs.
3. Observe the tab titles.

Expected: Tab is titled "Shell No. 1/2/3".
Actual: Tab is titled "QTermWidget".

### Evaluation

**Why are tabs named "QTermWidget"?** Because `TabWidget::onTermTitleChanged` receives the string `"QTermWidget"` and calls `setTabText` with it.

**Why is that string "QTermWidget"?** Because `QTermWidget::title()` falls back to `Session::title(NameRole)`, which is initialized to the hardcoded string `"QTermWidget"` in `TermWidgetImpl::createSession` (`qtermwidget/lib/qtermwidget.cpp:78`). This fallback is used when no escape sequence (OSC 0, 1, or 2) has explicitly set a title.

**Why is `title()` being queried at all?** Because `Session::titleChanged` is emitted, which propagates through `QTermWidget::titleChanged` to `TermWidget`'s lambda (`termwidget.cpp:324`), which unconditionally calls `m_term->title()` and emits `termTitleChanged`.

**Why is `titleChanged` being emitted when no title was set?** Because the new OSC 7 handler in `Session::setUserTitle` sets `modified = true`, which causes `titleChanged` to be emitted at the end of the function.

**Why does `modified = true` exist in the OSC 7 handler?** It is correct in the context of Konsole, where `titleChanged` (called `sessionAttributeChanged` in Konsole) triggers a _recomputation_ of the displayed title via `SessionController::sessionAttributeChanged` and `Session::getDynamicTitle`. Konsole uses tab title format strings (e.g., `%d` for the last directory component, `%D` for the full path) that dynamically incorporate the working directory. So when OSC 7 fires, Konsole recomputes the title and may show the new directory, which is the intended behavior.

**Root cause:** qterminal lacks the dynamic title computation layer that Konsole has. Konsole interposes a `SessionController` (a `ViewProperties` subclass) between `Session` and the tab UI; this controller recomputes the displayed title from format strings and process info on every `sessionAttributeChanged`. qterminal instead treats `titleChanged` as a literal "here is your new title string" event and directly calls `setTabText`. When the signal fires but no actual title has been set, the stale default `"QTermWidget"` is used.

### Solution

Guard the `titleChanged` -> `termTitleChanged` propagation in `TermWidget` with a check for `isTitleChanged()`, so that `titleChanged` signals that do not correspond to an actual title-setting escape sequence (OSC 0/1/2) are not propagated to the tab widget. This matches the existing guard pattern already used in `TermWidgetHolder::setCurrentTerminal`.

qtermwidget now exposes a `currentDirectoryChanged(const QString &dir)` signal. Once qtermwidget is released with OSC 7 support, a follow-up change could connect this signal in qterminal to optionally display the current working directory in the tab title, similar to how Konsole uses `%d` and `%D` format markers in its tab title format strings. The fix in this PR does not preclude that design; the `currentDirectoryChanged` signal path is independent of the `titleChanged` path guarded here.

Other options considered:

- **Alternative 1: Remove `modified = true` from the OSC 7 handler in qtermwidget's `Session::setUserTitle`.** This would fix the symptom but diverges qtermwidget's `Session` code from Konsole's, where `modified = true` is intentional and correct. It also masks qterminal's fragile title handling, which could be triggered again by any future session attribute change.

- **Alternative 2: Change `QTermWidget::title()` to not fall back to the hardcoded `"QTermWidget"` NameRole default.** This would change the library's public API behavior and could break other consumers of qtermwidget.

The chosen solution fixes the bug at the right layer (qterminal, where the architectural gap exists), keeps qtermwidget aligned with Konsole, and naturally composes with potential future work to consume the `currentDirectoryChanged` signal.

### Implementation

The fix is a single change in `termwidget.cpp`. We wrap the existing lambda with the same `isTitleChanged()` guard used in `TermWidgetHolder::setCurrentTerminal`. `isTitleChanged()` returns `true` only after an OSC 0, 1, or 2 escape sequence has explicitly set a title. Other session attribute changes (like OSC 7 directory updates) that emit `titleChanged` are filtered out, preventing the stale `"QTermWidget"` default from overwriting the tab label.

The relevant upstream code in qtermwidget's `Session::setUserTitle` intentionally sets `modified = true` for OSC 7, matching Konsole's design where `sessionAttributeChanged` triggers dynamic title recomputation. This is correct at the qtermwidget layer; the fix belongs in qterminal.

### Testing Done

Manual testing: verified that after the fix, new tabs retain their "Shell No. 1" names.

Closes https://github.com/lxqt/qtermwidget/pull/615