### PR TITLE
Add setColorScheme D-Bus method for runtime color scheme switching

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include <QApplication>
+#include <QTimer>
 #include <QtGlobal>
 
 #include <cassert>
@@ -390,6 +391,27 @@ bool QTerminalApp::isPrimaryInstance() {
   return m_isPrimaryInstance;
 }
 
+void QTerminalApp::setColorScheme(const QString &scheme)
+{
+    Properties *props = Properties::Instance();
+
+    // Block the file watcher to prevent loadSettings() from reverting
+    // the in-memory change when saveSettings() writes to disk.
+    props->blockWatcher(true);
+    props->colorScheme = scheme;
+    props->saveSettings();
+
+    for (MainWindow *wnd : std::as_const(m_windowList))
+    {
+        QMetaObject::invokeMethod(wnd, "propertiesChanged");
+    }
+
+    // Re-enable the file watcher after pending filesystem events are delivered,
+    // so that external config edits are still picked up going forward.
+    QTimer::singleShot(500, []() {
+        Properties::Instance()->blockWatcher(false);
+    });
+}
 
 #endif
 

--- a/src/org.lxqt.QTerminal.Process.xml
+++ b/src/org.lxqt.QTerminal.Process.xml
@@ -18,6 +18,9 @@
     <method name="toggleDropdown">
       <arg name="success" type="b" direction="out"/>
     </method>
+    <method name="setColorScheme">
+      <arg name="scheme" type="s" direction="in"/>
+    </method>
   </interface>
 </node>
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -46,12 +46,16 @@ Properties::Properties(const QString& filename)
     m_watcher = new QFileSystemWatcher();
     m_watcher->addPath(m_settings->fileName());
     QObject::connect(m_watcher, &QFileSystemWatcher::fileChanged, [this](const QString &path) {
-        if (m_settings)
+        if (m_settings && !m_watcherBlocked)
         {
             m_settings->sync();
             loadSettings();
             if (!m_watcher->files().contains(path))
                 m_watcher->addPath(path);
+        }
+        else if (m_settings && !m_watcher->files().contains(path))
+        {
+            m_watcher->addPath(path);
         }
     });
 }

--- a/src/properties.h
+++ b/src/properties.h
@@ -40,6 +40,7 @@ class Properties
         QFont defaultFont();
         void saveSettings();
         void loadSettings();
+        void blockWatcher(bool block) { m_watcherBlocked = block; }
         void migrate_settings();
         QString getShortcut(const QString &name, const QString &defaultShortcut) const;
         QString configDir() const;
@@ -149,6 +150,7 @@ class Properties
         QSettings *m_settings;
 
         QFileSystemWatcher *m_watcher;
+        bool m_watcherBlocked = false;
 };
 
 #endif

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -33,6 +33,7 @@ public:
     bool toggleDropdown();
     void requestDropDown();
     bool isPrimaryInstance();
+    void setColorScheme(const QString &scheme);
     #endif
 
     static void cleanup();


### PR DESCRIPTION
## Summary

- Adds a new `setColorScheme(string scheme)` method to the `org.lxqt.QTerminal.Process` D-Bus interface
- Allows changing the terminal color scheme at runtime without opening Preferences or restarting
- All open terminal windows and tabs repaint immediately

## Motivation

There is currently no way to programmatically switch qterminal's color scheme at runtime. The only options are to edit the config file (which isn't picked up live) or use the Preferences dialog interactively. This makes it impossible to:

- Bind a global hotkey to toggle between dark/light themes (e.g. for printer-friendly screenshots)
- Integrate with desktop-wide theme switchers
- Script theme changes for presentations or accessibility

## Changes

| File | Change |
|------|--------|
| `src/org.lxqt.QTerminal.Process.xml` | Add `setColorScheme` method to D-Bus interface |
| `src/qterminalapp.h` | Declare `setColorScheme` |
| `src/main.cpp` | Implement: update Properties, save, repaint all windows |
| `src/properties.h` | Add `blockWatcher()` method and `m_watcherBlocked` flag |
| `src/properties.cpp` | Respect `m_watcherBlocked` in file watcher callback |

## Usage

```bash
dbus-send --session --print-reply \
  --dest=org.lxqt.QTerminal-$(pgrep -x qterminal) / \
  org.lxqt.QTerminal.Process.setColorScheme string:"SolarizedLight"
```

## Test plan

- [x] Build and run qterminal
- [x] Call `setColorScheme` via `dbus-send` with various installed color schemes
- [ ] Verify all tabs and split terminals repaint immediately
- [ ] Verify the scheme persists to `qterminal.ini`
- [ ] Verify external config file edits are still picked up after the watcher re-enables
- [ ] Verify Preferences dialog reflects the updated scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)