### PR TITLE
Add properties support for new Fill background image mode

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -354,6 +354,11 @@
                <string>Center</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>Fill</string>
+              </property>
+             </item>
             </widget>
            </item>
            <item row="15" column="0">

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -118,7 +118,7 @@ void Properties::loadSettings()
 
     termTransparency = m_settings->value(QLatin1String("TerminalTransparency"), 0).toInt();
     backgroundImage = m_settings->value(QLatin1String("TerminalBackgroundImage"), QString()).toString();
-    backgroundMode = qBound(0, m_settings->value(QLatin1String("TerminalBackgroundMode"), 0).toInt(), 4);
+    backgroundMode = qBound(0, m_settings->value(QLatin1String("TerminalBackgroundMode"), 0).toInt(), 5);
 
     /* default to Right. see qtermwidget.h */
     scrollBarPos = m_settings->value(QLatin1String("ScrollbarPosition"), 2).toInt();

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -355,7 +355,7 @@ void PropertiesDialog::apply()
     Properties::Instance()->focusOnMoueOver = focusOnMoueOverCheckBox->isChecked();
     Properties::Instance()->showTerminalSizeHint = showTerminalSizeHintCheckBox->isChecked();
     Properties::Instance()->backgroundImage = backgroundImageLineEdit->text();
-    Properties::Instance()->backgroundMode = qBound(0, backgroundModecomboBox->currentIndex(), 4);
+    Properties::Instance()->backgroundMode = qBound(0, backgroundModecomboBox->currentIndex(), 5);
 
     Properties::Instance()->askOnExit = askOnExitCheckBox->isChecked();
 


### PR DESCRIPTION
Changes properties window to accept a new background image mode.

Closes issue #1326 when combined with my other PR on qtermwidget ( https://github.com/lxqt/qtermwidget/pull/651 )