### PR TITLE
tr: Use plain names for cursor shapes

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -532,9 +532,9 @@ void MainWindow::setup_ViewMenu_Actions()
     /* Keyboard cursor shape */
     if (keyboardCursorShape == nullptr) {
         keyboardCursorShape = new QActionGroup(this);
-        QAction *block = new QAction(tr("&BlockCursor"), this);
-        QAction *underline = new QAction(tr("&UnderlineCursor"), this);
-        QAction *ibeam = new QAction(tr("&IBeamCursor"), this);
+        QAction *block = new QAction(tr("&Block"), this);
+        QAction *underline = new QAction(tr("&Underline"), this);
+        QAction *ibeam = new QAction(tr("&I-Beam"), this);
 
         /* order of insertion is dep. on QTermWidget::KeyboardCursorShape enum */
         keyboardCursorShape->addAction(block);

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -183,7 +183,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     /* keyboard cursor shape */
     QStringList keyboardCursorShapeList;
-    keyboardCursorShapeList << tr("BlockCursor") << tr("UnderlineCursor") << tr("IBeamCursor");
+    keyboardCursorShapeList << tr("Block") << tr("Underline") << tr("I-Beam");
     keybCursorShape_comboBox->addItems(keyboardCursorShapeList);
     keybCursorShape_comboBox->setCurrentIndex(Properties::Instance()->keyboardCursorShape);
 


### PR DESCRIPTION
In the GUI:
- "BlockCursor" → "Block"
- "UnderlineCursor" → "Underline"
- "IBeamCursor" → "I-Beam"

This will reset these translations but I think it's gainful to not use identifier-type strings.