### PR TITLE
Add OSC-8 hyperlink settings to properties

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -818,20 +818,50 @@
                </widget>
               </item>
               <item row="8" column="0" colspan="2">
+               <widget class="QCheckBox" name="enableOsc8HyperlinksCheckBox">
+                <property name="toolTip">
+                 <string>Allow applications to embed clickable hyperlinks using the OSC-8 terminal sequence</string>
+                </property>
+                <property name="text">
+                 <string>Enable OSC-8 hyperlinks</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="0" colspan="2">
+               <widget class="QCheckBox" name="showLinkTooltipsCheckBox">
+                <property name="toolTip">
+                 <string>Show the destination URL when hovering over a link</string>
+                </property>
+                <property name="text">
+                 <string>Show link destination on hover</string>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="0" colspan="2">
+               <widget class="QCheckBox" name="openLinksByCtrlClickCheckBox">
+                <property name="toolTip">
+                 <string>When enabled, links open only with Ctrl+Click or from the context menu. When disabled, a plain click opens the link.</string>
+                </property>
+                <property name="text">
+                 <string>Open links with Ctrl+Click</string>
+                </property>
+               </widget>
+              </item>
+              <item row="11" column="0" colspan="2">
                <widget class="QCheckBox" name="askOnExitCheckBox">
                 <property name="text">
                  <string>Prompt on closing with a running process</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="0" colspan="2">
+              <item row="12" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="10" column="0" colspan="2">
+              <item row="13" column="0" colspan="2">
                <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
                 <property name="toolTip">
                  <string>If unchecked the new tab will be opened as the rightmost tab</string>
@@ -841,21 +871,21 @@
                 </property>
                </widget>
               </item>
-              <item row="11" column="0">
+              <item row="14" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
                 </property>
                </widget>
               </item>
-              <item row="12" column="0">
+              <item row="15" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="12" column="1">
+              <item row="15" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -881,10 +911,10 @@
                 </item>
                </widget>
               </item>
-              <item row="13" column="1">
+              <item row="16" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
-              <item row="13" column="0">
+              <item row="16" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history</string>

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -190,6 +190,10 @@ void Properties::loadSettings()
     trimPastedTrailingNewlines = m_settings->value(QLatin1String("TrimPastedTrailingNewlines"), false).toBool();
     wordCharacters = m_settings->value(QLatin1String("WordCharacters"), QLatin1String(":@-./_~")).toString();
 
+    enableOsc8Hyperlinks = m_settings->value(QLatin1String("EnableOsc8Hyperlinks"), true).toBool();
+    showLinkTooltips = m_settings->value(QLatin1String("ShowLinkTooltips"), true).toBool();
+    openLinksByCtrlClick = m_settings->value(QLatin1String("OpenLinksByCtrlClick"), true).toBool();
+
     windowMaximized = m_settings->value(QLatin1String("LastWindowMaximized"), false).toBool();
 
     swapMouseButtons2and3 = m_settings->value(QLatin1String("SwapMouseButtons2and3"), false).toBool();
@@ -315,6 +319,10 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("ConfirmMultilinePaste"), confirmMultilinePaste);
     m_settings->setValue(QLatin1String("TrimPastedTrailingNewlines"), trimPastedTrailingNewlines);
     m_settings->setValue(QLatin1String("WordCharacters"), wordCharacters);
+
+    m_settings->setValue(QLatin1String("EnableOsc8Hyperlinks"), enableOsc8Hyperlinks);
+    m_settings->setValue(QLatin1String("ShowLinkTooltips"), showLinkTooltips);
+    m_settings->setValue(QLatin1String("OpenLinksByCtrlClick"), openLinksByCtrlClick);
 
     m_settings->setValue(QLatin1String("LastWindowMaximized"), windowMaximized);
     m_settings->setValue(QLatin1String("SwapMouseButtons2and3"), swapMouseButtons2and3);

--- a/src/properties.h
+++ b/src/properties.h
@@ -24,6 +24,7 @@
 #include <QFont>
 #include <QFileSystemWatcher>
 #include <QString>
+#include <qkeysequence.h>
 
 typedef QString Session;
 
@@ -130,6 +131,13 @@ class Properties
         bool confirmMultilinePaste;
         bool trimPastedTrailingNewlines;
         QString wordCharacters;
+
+        /** Parse and expose OSC-8 hyperlinks from applications. */
+        bool enableOsc8Hyperlinks;
+        /** Show destination URL tooltip when hovering links. */
+        bool showLinkTooltips;
+        /** Open links only with Ctrl+Click (or context menu); if false, plain click opens. */
+        bool openLinksByCtrlClick;
 
         bool windowMaximized;
         bool swapMouseButtons2and3;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -306,6 +306,9 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
 
     trimPastedTrailingNewlinesCheckBox->setChecked(Properties::Instance()->trimPastedTrailingNewlines);
     confirmMultilinePasteCheckBox->setChecked(Properties::Instance()->confirmMultilinePaste);
+    enableOsc8HyperlinksCheckBox->setChecked(Properties::Instance()->enableOsc8Hyperlinks);
+    showLinkTooltipsCheckBox->setChecked(Properties::Instance()->showLinkTooltips);
+    openLinksByCtrlClickCheckBox->setChecked(Properties::Instance()->openLinksByCtrlClick);
 
     // save the size on canceling too (it's saved on accepting by apply())
     connect(this, &QDialog::rejected, [this] {
@@ -416,6 +419,9 @@ void PropertiesDialog::apply()
     Properties::Instance()->trimPastedTrailingNewlines = trimPastedTrailingNewlinesCheckBox->isChecked();
     Properties::Instance()->confirmMultilinePaste = confirmMultilinePasteCheckBox->isChecked();
     Properties::Instance()->wordCharacters = wordCharactersLineEdit->text();
+    Properties::Instance()->enableOsc8Hyperlinks = enableOsc8HyperlinksCheckBox->isChecked();
+    Properties::Instance()->showLinkTooltips = showLinkTooltipsCheckBox->isChecked();
+    Properties::Instance()->openLinksByCtrlClick = openLinksByCtrlClickCheckBox->isChecked();
 
     int autoDelay = mouseAutoHideSpinBox->value();
     if (autoDelay > 0)

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -117,6 +117,8 @@ void TermWidgetImpl::propertiesChanged()
     autoHideMouseAfter(Properties::Instance()->mouseAutoHideDelay);
     setTrimPastedTrailingNewlines(Properties::Instance()->trimPastedTrailingNewlines);
     setTerminalSizeHint(Properties::Instance()->showTerminalSizeHint);
+    setOsc8HyperlinksEnabled(Properties::Instance()->enableOsc8Hyperlinks);
+    setLinkTooltipsEnabled(Properties::Instance()->showLinkTooltips);
 
     if (Properties::Instance()->historyLimited)
     {
@@ -239,7 +241,9 @@ void TermWidgetImpl::zoomReset()
 }
 
 void TermWidgetImpl::activateUrl(const QUrl & url, bool fromContextMenu) {
-    if (QApplication::keyboardModifiers() & Qt::ControlModifier || fromContextMenu) {
+    if (fromContextMenu
+        || !Properties::Instance()->openLinksByCtrlClick
+        || (QApplication::keyboardModifiers() & Qt::ControlModifier)) {
         QDesktopServices::openUrl(url);
     }
 }


### PR DESCRIPTION
## ✨🖱️ OSC-8 Hyperlinks for QTerminal 🔗🚀

Clickable terminal links, but make it *configurable* 😎💅

Users can now:
- ✅ Enable / disable OSC-8 hyperlinks
- 👀 Show link destination tooltips on hover
- ⌨️ Choose **Ctrl+Click** vs plain click to open links

### 🧩 What’s changed

#### 🎛️ Preferences UI (`propertiesdialog.ui`)
Added three shiny new checkboxes in Behavior:
- 🔗 **Enable OSC-8 hyperlinks** — apps can embed clickable links via OSC-8
- 💬 **Show link destination on hover** — see the URL before you leap
- 🖱️ **Open links with Ctrl+Click** — safer browsing in the shell


### 🖥️ Companion PR — **qtermwidget**
https://github.com/lxqt/qtermwidget/pull/654

<img width="1201" height="1007" alt="image" src="https://github.com/user-attachments/assets/46db783f-e8d3-4d06-a28f-feb77eea13f8" />


