### PR TITLE
tabwidget: connect currentChanged->currentTitleChanged once in ctor, fix #357

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -66,6 +66,7 @@ TabWidget::TabWidget(QWidget* parent) : QTabWidget(parent), tabNumerator(0), mTa
     connect(this, &TabWidget::tabTitleColorChangeRequested, this, &TabWidget::setTitleColor);
     connect(mSwitcher.data(), &TabSwitcher::activateTab, this, &TabWidget::switchTab);
     connect(this, &TabWidget::currentChanged, this, &TabWidget::onCurrentChanged);
+    connect(this, &QTabWidget::currentChanged, this, &TabWidget::currentTitleChanged);
 }
 
 TabWidget::~TabWidget()
@@ -93,7 +94,6 @@ int TabWidget::addNewTab(TerminalConfig config)
     connect(console, &TermWidgetHolder::finished, this, &TabWidget::removeFinished);
     connect(console, &TermWidgetHolder::lastTerminalClosed, this, &TabWidget::removeFinished);
     connect(console, &TermWidgetHolder::termTitleChanged, this, &TabWidget::onTermTitleChanged);
-    connect(this, &QTabWidget::currentChanged, this, &TabWidget::currentTitleChanged);
 
     const int newIndex = (Properties::Instance()->m_openNewTabRightToActiveTab ? currentIndex() + 1 : count());
     const int index = insertTab(newIndex, console, label);


### PR DESCRIPTION
Fixes #357

The forward connection was created inside addNewTab() on every new tab and never disconnected, so after N tabs each currentChanged() fired N currentTitleChanged() emissions, each running MainWindow::onCurrentTitleChanged (a ~50ms setWindowIcon on X11). Tab switching and creation became O(total tabs ever created); closing tabs did not help because the connections stayed on the TabWidget itself.

Move the signal-to-signal forward into the constructor so it is connected exactly once for the widget's lifetime.