### PR TITLE
Ipc

### DIFF
--- a/src/dbusaddressable.cpp
+++ b/src/dbusaddressable.cpp
@@ -18,11 +18,16 @@ QDBusObjectPath DBusAddressable::getDbusPath()
 }
 #endif
 
-DBusAddressable::DBusAddressable(const QString& prefix)
+DBusAddressable::DBusAddressable(const QString& prefix, const QString& name)
 {
     #ifdef HAVE_QDBUS
-    QString uuidString = QUuid::createUuid().toString();
-    static const QRegularExpression regExp{u"[\\{\\}\\-]"_s};
-    m_path = prefix + QLatin1Char('/') + uuidString.replace(regExp, QString());
+    QString suffix = name;
+    if (suffix.isEmpty())
+    {
+        QString uuidString = QUuid::createUuid().toString();
+        static const QRegularExpression regExp{u"[\\{\\}\\-]"_s};
+        suffix = uuidString.replace(regExp, QString());
+    }
+    m_path = prefix + QLatin1Char('/') + suffix;
     #endif
 }

--- a/src/dbusaddressable.h
+++ b/src/dbusaddressable.h
@@ -18,7 +18,7 @@ class DBusAddressable
         QDBusObjectPath getDbusPath();
         QString getDbusPathString();
     #endif
-        DBusAddressable(const QString& prefix);
+        DBusAddressable(const QString& prefix, const QString &name = QString());
 };
 
 #ifdef HAVE_QDBUS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@
 
 #define out
 
-const char* const short_options = "vhw:e:dp:";
+const char* const short_options = "vhw:e:dp:i:";
 
 static const char* serviceName = "org.lxqt.QTerminal";
 static const char* ifaceName = "org.lxqt.QTerminal.Process";
@@ -51,6 +51,7 @@ const struct option long_options[] = {
     {"execute", 1, nullptr, 'e'},
     {"drop",    0, nullptr, 'd'},
     {"profile", 1, nullptr, 'p'},
+    {"dbus_id", 1, nullptr, 'i'},
     {nullptr,   0, nullptr,  0}
 };
 
@@ -63,6 +64,7 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
     puts("  -d,  --drop               Start in \"dropdown mode\" (like Yakuake or Tilda)");
     puts("  -e,  --execute <command>  Execute command instead of shell");
     puts("  -h,  --help               Print this help");
+    puts("  -i,  --dbus_id <name>     Register with predetermined dbus interface, org.lxqt.QTerminal-<id>");
     puts("  -p,  --profile <name>     Load profile from ~/.config/<name>.conf");
     puts("  -v,  --version            Prints application version and exits");
     puts("  -w,  --workdir <dir>      Start session with specified work directory");
@@ -77,7 +79,7 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
     exit(code);
 }
 
-void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode)
+void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode, QString &dbus_id)
 {
     int next_option = 0;
     dropMode = false;
@@ -106,6 +108,9 @@ void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_co
                 break;
             case 'p':
                 Properties::Instance(QString::fromLocal8Bit(optarg));
+                break;
+            case 'i':
+                dbus_id = QString::fromLocal8Bit(optarg);
                 break;
             case '?':
                 print_usage_and_exit(1);
@@ -153,10 +158,11 @@ int main(int argc, char *argv[])
     QString workdir;
     QStringList shell_command;
     bool dropMode = false;
-    parse_args(argc, argv, workdir, shell_command, dropMode);
+    QString dbus_id;
+    parse_args(argc, argv, workdir, shell_command, dropMode, dbus_id);
 
     #ifdef HAVE_QDBUS
-        app->registerOnDbus(dropMode);
+        app->registerOnDbus(dropMode, dbus_id);
     #endif
 
     if (!app->isPrimaryInstance())
@@ -302,7 +308,7 @@ QList<MainWindow *> QTerminalApp::getWindowList()
 }
 
 #ifdef HAVE_QDBUS
-void QTerminalApp::registerOnDbus(bool dropDown)
+void QTerminalApp::registerOnDbus(bool dropDown, QString dbus_id)
 {
     if (!QDBusConnection::sessionBus().isConnected())
     {
@@ -324,8 +330,8 @@ void QTerminalApp::registerOnDbus(bool dropDown)
     }
     else
     {
-        if (!QDBusConnection::sessionBus().registerService(QLatin1String(serviceName)
-                                                           + QStringLiteral("-%1").arg(getpid())))
+        const QString suffix = dbus_id.isEmpty() ? QStringLiteral("-%1").arg(getpid()) : QStringLiteral("-%1").arg(dbus_id);
+        if (!QDBusConnection::sessionBus().registerService(QLatin1String(serviceName) + suffix))
         {
             fprintf(stderr, "%s\n", qPrintable(QDBusConnection::sessionBus().lastError().message()));
             return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,10 +36,11 @@
 #include "qterminalapp.h"
 #include "qterminalutils.h"
 #include "terminalconfig.h"
+#include "termwidget.h"
 
 #define out
 
-const char* const short_options = "vhw:e:dp:i:";
+const char* const short_options = "vhw:e:dp:i:s:";
 
 static const char* serviceName = "org.lxqt.QTerminal";
 static const char* ifaceName = "org.lxqt.QTerminal.Process";
@@ -52,6 +53,7 @@ const struct option long_options[] = {
     {"drop",    0, nullptr, 'd'},
     {"profile", 1, nullptr, 'p'},
     {"dbus_id", 1, nullptr, 'i'},
+    {"size",    1, nullptr, 's'},
     {nullptr,   0, nullptr,  0}
 };
 
@@ -66,6 +68,7 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
     puts("  -h,  --help               Print this help");
     puts("  -i,  --dbus_id <name>     Register with predetermined dbus interface, org.lxqt.QTerminal-<id>");
     puts("  -p,  --profile <name>     Load profile from ~/.config/<name>.conf");
+    puts("  -s,  --size    <CxL>      Set initial size in columns and lines");
     puts("  -v,  --version            Prints application version and exits");
     puts("  -w,  --workdir <dir>      Start session with specified work directory");
     puts("\nHomepage: <https://github.com/lxqt/qterminal>");
@@ -79,7 +82,7 @@ QTerminalApp * QTerminalApp::m_instance = nullptr;
     exit(code);
 }
 
-void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode, QString &dbus_id)
+void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_command, out bool& dropMode, QString &dbus_id, QSize &size)
 {
     int next_option = 0;
     dropMode = false;
@@ -112,6 +115,18 @@ void parse_args(int argc, char* argv[], QString& workdir, QStringList & shell_co
             case 'i':
                 dbus_id = QString::fromLocal8Bit(optarg);
                 break;
+            case 's':
+            {
+                QStringList values = QString::fromLocal8Bit(optarg).split(QStringLiteral("x"));
+                if (values.size() == 2)
+                {
+                    int cols = values.at(0).toInt();
+                    int lines = values.at(1).toInt();
+                    if (cols > 0 && lines > 0)
+                        size = QSize(cols, lines);
+                }
+                break;
+            }
             case '?':
                 print_usage_and_exit(1);
                 break;
@@ -159,7 +174,8 @@ int main(int argc, char *argv[])
     QStringList shell_command;
     bool dropMode = false;
     QString dbus_id;
-    parse_args(argc, argv, workdir, shell_command, dropMode, dbus_id);
+    QSize size;
+    parse_args(argc, argv, workdir, shell_command, dropMode, dbus_id, size);
 
     #ifdef HAVE_QDBUS
         app->registerOnDbus(dropMode, dbus_id);
@@ -227,7 +243,8 @@ int main(int argc, char *argv[])
     }
 
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
-    app->newWindow(dropMode, initConfig, dbus_id);
+    if (MainWindow *wnd = app->newWindow(dropMode, initConfig, dbus_id))
+        wnd->setInitialSize(size);
 
     int ret = app->exec();
     delete Properties::Instance();
@@ -253,7 +270,8 @@ MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg, const QS
         {
             window->setWindowState(Qt::WindowMaximized);
         }
-        window->show();
+        // this gives us time to resize the window on user control
+        QMetaObject::invokeMethod(window, "show", Qt::QueuedConnection);
     }
     return window;
 }
@@ -353,11 +371,13 @@ QList<QDBusObjectPath> QTerminalApp::getWindows()
     return windows;
 }
 
-QDBusObjectPath QTerminalApp::newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir)
+QDBusObjectPath QTerminalApp::newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir, int columns, int lines)
 {
     TerminalConfig cfg = TerminalConfig(workdir.isEmpty() ? m_workDir : workdir, parse_command(shell_command));
     MainWindow *wnd = newWindow(false, cfg, dbus_id);
     assert(wnd != nullptr);
+    if (columns > 0 || lines > 0)
+        wnd->setInitialSize(QSize(columns, lines));
     return wnd->getDbusPath();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,6 +325,7 @@ void QTerminalApp::registerOnDbus(bool dropDown, QString dbus_id)
             m_isPrimaryInstance = false;
             return;
         }
+        m_dbusService = QLatin1String(serviceName);
         new ProcessAdaptor(this);
         QDBusConnection::sessionBus().registerObject(QStringLiteral("/"), this);
     }
@@ -336,6 +337,7 @@ void QTerminalApp::registerOnDbus(bool dropDown, QString dbus_id)
             fprintf(stderr, "%s\n", qPrintable(QDBusConnection::sessionBus().lastError().message()));
             return;
         }
+        m_dbusService = QLatin1String(serviceName) + suffix;
         new ProcessAdaptor(this);
         QDBusConnection::sessionBus().registerObject(QStringLiteral("/"), this);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,7 +227,7 @@ int main(int argc, char *argv[])
     }
 
     TerminalConfig initConfig = TerminalConfig(workdir, shell_command);
-    app->newWindow(dropMode, initConfig);
+    app->newWindow(dropMode, initConfig, dbus_id);
 
     int ret = app->exec();
     delete Properties::Instance();
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
     return ret;
 }
 
-MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg)
+MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg, const QString &dbus_id)
 {
     MainWindow *window = nullptr;
     if (dropMode)
@@ -247,7 +247,7 @@ MainWindow *QTerminalApp::newWindow(bool dropMode, TerminalConfig &cfg)
     }
     else
     {
-        window = new MainWindow(cfg, dropMode);
+        window = new MainWindow(cfg, dropMode, dbus_id);
         if (Properties::Instance()->saveSizeOnExit
             && Properties::Instance()->windowMaximized)
         {
@@ -349,6 +349,14 @@ QList<QDBusObjectPath> QTerminalApp::getWindows()
         windows.push_back(wnd->getDbusPath());
     }
     return windows;
+}
+
+QDBusObjectPath QTerminalApp::newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir)
+{
+    TerminalConfig cfg = TerminalConfig(workdir.isEmpty() ? m_workDir : workdir, parse_command(shell_command));
+    MainWindow *wnd = newWindow(false, cfg, dbus_id);
+    assert(wnd != nullptr);
+    return wnd->getDbusPath();
 }
 
 QDBusObjectPath QTerminalApp::newWindow(const QHash<QString,QVariant> &termArgs)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -935,6 +935,15 @@ void MainWindow::showEvent(QShowEvent* event)
         int vMargin = desktop.height() * (100 - Properties::Instance()->dropHeight) / 100;
         m_layerWindow->setMargins(QMargins(hMargin, 0, hMargin, vMargin));
     }
+
+    if (m_initialSize.isValid())
+    {
+        QList<TermWidget*> twl = findChildren<TermWidget*>();
+        if (twl.size() > 0)
+            twl.at(0)->setSize(m_initialSize.width(), m_initialSize.height());
+        m_initialSize = QSize();
+    }
+
     QMainWindow::showEvent(event);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1085,4 +1085,18 @@ void MainWindow::closeWindow()
     close();
 }
 
+void MainWindow::activateOrHide()
+{
+    if (isActiveWindow())
+    {
+        hide();
+    }
+    else
+    {
+        show();
+        activateWindow();
+        raise();
+    }
+}
+
 #endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -52,10 +52,11 @@ Q_DECLARE_METATYPE(checkfn)
 
 MainWindow::MainWindow(TerminalConfig &cfg,
                        bool dropMode,
+                       const QString &dbus_id,
                        QWidget * parent,
                        Qt::WindowFlags f)
     : QMainWindow(parent,f),
-      DBusAddressable(QStringLiteral("/windows")),
+      DBusAddressable(QStringLiteral("/windows"), dbus_id),
       tabPosition(nullptr),
       scrollBarPosition(nullptr),
       keyboardCursorShape(nullptr),

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -43,6 +43,7 @@
 #include "bookmarkswidget.h"
 #include "qterminalapp.h"
 #include "dbusaddressable.h"
+#include "qterminalutils.h"
 
 #include <LayerShellQt/Shell>
 #include <LayerShellQt/Window>
@@ -149,7 +150,7 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     /* The tab should be added after all changes are made to
        the main window; otherwise, the initial prompt might
        get jumbled because of changes in internal geometry. */
-    addNewTab(m_config);
+    addNewTab(m_config, dbus_id);
 }
 
 void MainWindow::rebuildActions()
@@ -985,12 +986,12 @@ void MainWindow::bookmarksDock_visibilityChanged(bool visible)
     }
 }
 
-void MainWindow::addNewTab(TerminalConfig cfg)
+void MainWindow::addNewTab(TerminalConfig cfg, const QString &dbus_id)
 {
     if (cfg.hasCommand())
     {
         // do not create subterminals if there is a command (-e option)
-        consoleTabulator->addNewTab(cfg);
+        consoleTabulator->addNewTab(cfg, dbus_id);
         return;
     }
 
@@ -1001,7 +1002,7 @@ void MainWindow::addNewTab(TerminalConfig cfg)
     else if (Properties::Instance()->terminalsPreset == 1)
         consoleTabulator->preset2Horizontal();
     else
-        consoleTabulator->addNewTab(cfg);
+        consoleTabulator->addNewTab(cfg, dbus_id);
     // disabled actions are updated by TabWidget::onCurrentChanged()
 }
 
@@ -1080,6 +1081,14 @@ QDBusObjectPath MainWindow::newTab(const QHash<QString,QVariant> &termArgs)
     int idx = consoleTabulator->addNewTab(cfg);
     return qobject_cast<TermWidgetHolder*>(consoleTabulator->widget(idx))->getDbusPath();
 }
+
+QDBusObjectPath MainWindow::newTab(const QString &dbus_id, const QString &shell_command, const QString& workdir)
+{
+    TerminalConfig cfg = TerminalConfig(workdir.isEmpty() ? QTerminalApp::Instance()->getWorkingDirectory() : workdir, parse_command(shell_command));
+    int idx = consoleTabulator->addNewTab(cfg, dbus_id);
+    return qobject_cast<TermWidgetHolder*>(consoleTabulator->widget(idx))->getDbusPath();
+}
+
 
 void MainWindow::closeWindow()
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -56,6 +56,7 @@ public:
     QList<QDBusObjectPath> getTabs();
     QDBusObjectPath newTab(const QHash<QString,QVariant> &termArgs);
     void closeWindow();
+    void activateOrHide();
     #endif
 
 protected:

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -40,7 +40,7 @@ class MainWindow : public QMainWindow, private Ui::mainWindow, public DBusAddres
 
 public:
     MainWindow(TerminalConfig& cfg,
-               bool dropMode,
+               bool dropMode, const QString &dbus_id = QString(),
                QWidget * parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
     ~MainWindow() override;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -51,6 +51,8 @@ public:
 
     bool closePrompt(const QString &title, const QString &text);
 
+    void setInitialSize(QSize size) { m_initialSize = size; }
+
     #ifdef HAVE_QDBUS
     QDBusObjectPath getActiveTab();
     QList<QDBusObjectPath> getTabs();
@@ -74,6 +76,7 @@ private:
 
     QMenu *presetsMenu;
     TerminalConfig m_config;
+    QSize m_initialSize;
 
     QDockWidget *m_bookmarksDock;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -55,6 +55,7 @@ public:
     QDBusObjectPath getActiveTab();
     QList<QDBusObjectPath> getTabs();
     QDBusObjectPath newTab(const QHash<QString,QVariant> &termArgs);
+    QDBusObjectPath newTab(const QString &dbus_id, const QString &shell_command, const QString& workdir);
     void closeWindow();
     void activateOrHide();
     #endif
@@ -126,7 +127,7 @@ private slots:
     void bookmarksWidget_callCommand(const QString&);
     void bookmarksDock_visibilityChanged(bool visible);
 
-    void addNewTab(TerminalConfig cfg = TerminalConfig());
+    void addNewTab(TerminalConfig cfg = TerminalConfig(), const QString &dbus_id = QString());
     void onCurrentTitleChanged(int index);
 
     void handleHistory();

--- a/src/org.lxqt.QTerminal.Process.xml
+++ b/src/org.lxqt.QTerminal.Process.xml
@@ -9,6 +9,11 @@
       <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
       <arg name="termArgs" type="a{sv}" direction="in"/>
     </method>
+    <method name="newWindow">
+      <arg name="dbus_id" type="s" direction="in"/>
+      <arg name="shell_command" type="s" direction="in"/>
+      <arg name="workdir" type="s" direction="in"/>
+    </method>
     <method name="getActiveWindow">
       <arg name="window" type="o" direction="out"/>
     </method>

--- a/src/org.lxqt.QTerminal.Process.xml
+++ b/src/org.lxqt.QTerminal.Process.xml
@@ -13,6 +13,8 @@
       <arg name="dbus_id" type="s" direction="in"/>
       <arg name="shell_command" type="s" direction="in"/>
       <arg name="workdir" type="s" direction="in"/>
+      <arg name="columns" type="i" direction="in"/>
+      <arg name="lines" type="i" direction="in"/>
     </method>
     <method name="getActiveWindow">
       <arg name="window" type="o" direction="out"/>

--- a/src/org.lxqt.QTerminal.Tab.xml
+++ b/src/org.lxqt.QTerminal.Tab.xml
@@ -12,6 +12,9 @@
       <arg name="window" type="o" direction="out"/>
     </method>
     <method name="closeTab"/>
+    <method name="setLabel">
+      <arg name="label" type="s" direction="in"/>
+    </method>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -7,9 +7,23 @@
         <arg name="termArgs" type="a{sv}" direction="in"/>
         <arg name="newTerminal" type="o" direction="out"/>
     </method>
+    <method name="splitVertical">
+        <arg name="dbus_id" type="s" direction="in"/>
+        <arg name="shell_command" type="s" direction="in"/>
+        <arg name="workdir" type="s" direction="in"/>
+        <arg name="newPercent" type="i" direction="in"/>
+        <arg name="newTerminal" type="o" direction="out"/>
+    </method>
     <method name="splitHorizontal">
         <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QHash&lt;QString,QVariant&gt;"/>
         <arg name="termArgs" type="a{sv}" direction="in"/>
+        <arg name="newTerminal" type="o" direction="out"/>
+    </method>
+    <method name="splitHorizontal">
+        <arg name="dbus_id" type="s" direction="in"/>
+        <arg name="shell_command" type="s" direction="in"/>
+        <arg name="workdir" type="s" direction="in"/>
+        <arg name="newPercent" type="i" direction="in"/>
         <arg name="newTerminal" type="o" direction="out"/>
     </method>
     <method name="getTab">

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -26,6 +26,10 @@
       <arg name="file" type="s" direction="in"/>
       <arg name="mode" type="i" direction="in"/>
     </method>
+    <method name="setFont">
+      <arg name="text" type="s" direction="in"/>
+      <arg name="text" type="i" direction="in"/>
+    </method>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -30,6 +30,10 @@
       <arg name="text" type="s" direction="in"/>
       <arg name="text" type="i" direction="in"/>
     </method>
+    <method name="setSize">
+      <arg name="columns" type="i" direction="in"/>
+      <arg name="lines" type="i" direction="in"/>
+    </method>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -19,6 +19,13 @@
         <arg name="text" type="s" direction="in"/>
     </method>
     <method name="closeTerminal"/>
+    <method name="setColorScheme">
+      <arg name="text" type="s" direction="in"/>
+    </method>
+    <method name="setBackgroundImage">
+      <arg name="file" type="s" direction="in"/>
+      <arg name="mode" type="i" direction="in"/>
+    </method>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Window.xml
+++ b/src/org.lxqt.QTerminal.Window.xml
@@ -13,6 +13,12 @@
       <arg name="termArgs" type="a{sv}" direction="in"/>
       <arg name="newTerminal" type="o" direction="out"/>
     </method>
+    <method name="newTab">
+      <arg name="dbus_id" type="s" direction="in"/>
+      <arg name="shell_command" type="s" direction="in"/>
+      <arg name="workdir" type="s" direction="in"/>
+      <arg name="newTerminal" type="o" direction="out"/>
+    </method>
     <method name="closeWindow"/>
     <method name="activateWindow"/>
     <method name="activateOrHide"/>

--- a/src/org.lxqt.QTerminal.Window.xml
+++ b/src/org.lxqt.QTerminal.Window.xml
@@ -15,6 +15,7 @@
     </method>
     <method name="closeWindow"/>
     <method name="activateWindow"/>
+    <method name="activateOrHide"/>
   </interface>
 </node>
 

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -25,7 +25,7 @@ public:
     void setWorkingDirectory(const QString &wd);
 
     #ifdef HAVE_QDBUS
-    void registerOnDbus(bool dropDown);
+    void registerOnDbus(bool dropDown, const QString dbus_id);
     QList<QDBusObjectPath> getWindows();
     QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
     QDBusObjectPath getActiveWindow();

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -28,7 +28,7 @@ public:
     void registerOnDbus(bool dropDown, const QString dbus_id);
     QString getDbusService() const { return m_dbusService; }
     QList<QDBusObjectPath> getWindows();
-    QDBusObjectPath newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir);
+    QDBusObjectPath newWindow(const QString &dbus_id, const QString &shell_command, const QString &workdir, int columns, int lines);
     QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
     QDBusObjectPath getActiveWindow();
     bool isDropMode();

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -15,7 +15,7 @@ class QTerminalApp : public QApplication
 Q_OBJECT
 
 public:
-    MainWindow *newWindow(bool dropMode, TerminalConfig &cfg);
+    MainWindow *newWindow(bool dropMode, TerminalConfig &cfg, const QString &dbus_id = QString());
     QList<MainWindow*> getWindowList();
     void addWindow(MainWindow *window);
     void removeWindow(MainWindow *window);
@@ -27,6 +27,7 @@ public:
     #ifdef HAVE_QDBUS
     void registerOnDbus(bool dropDown, const QString dbus_id);
     QList<QDBusObjectPath> getWindows();
+    QDBusObjectPath newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir);
     QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
     QDBusObjectPath getActiveWindow();
     bool isDropMode();

--- a/src/qterminalapp.h
+++ b/src/qterminalapp.h
@@ -26,6 +26,7 @@ public:
 
     #ifdef HAVE_QDBUS
     void registerOnDbus(bool dropDown, const QString dbus_id);
+    QString getDbusService() const { return m_dbusService; }
     QList<QDBusObjectPath> getWindows();
     QDBusObjectPath newWindow(const QString &dbus_id, const QString &shell_command, const QString& workdir);
     QDBusObjectPath newWindow(const QHash<QString,QVariant> &termArgs);
@@ -43,6 +44,9 @@ private:
     QList<MainWindow *> m_windowList;
     static QTerminalApp *m_instance;
     bool m_isPrimaryInstance = true;
+#ifdef HAVE_QDBUS
+    QString m_dbusService;
+#endif
     QTerminalApp(int &argc, char **argv);
     ~QTerminalApp() override{};
 };

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -220,50 +220,53 @@ void TabWidget::onTermTitleChanged(const QString& title, const QString& icon)
     }
 }
 
-void TabWidget::renameSession(int index)
+void TabWidget::setLabel(int index, const QString &text)
 {
-    bool ok = false;
     QString previous_text = tabText(index);
-    QString text = QInputDialog::getText(this, tr("Tab name"),
-                                        tr("New tab name:"), QLineEdit::Normal,
-                                        previous_text, &ok).simplified();
-    if(ok)
+    const QVariant system_title = widget(index)->property(TAB_SYSTEM_TITLE_PROPERTY);
+    if (system_title.isValid()) /* Do we already have a custom title ? */
     {
-        const QVariant system_title = widget(index)->property(TAB_SYSTEM_TITLE_PROPERTY);
-        if (system_title.isValid()) /* Do we already have a custom title ? */
+        /* Stop custom title when text is empty or match the default system value */
+        if (text.isEmpty() || text==system_title.toString())
         {
-            /* Stop custom title when text is empty or match the default system value */
-            if (text.isEmpty() || text==system_title.toString())
-            {
-                /* Restore the stored title */
-                setTabIcon(index, QIcon{});
-                setTabText(index, system_title.toString());
-                /* Reset the stored title memory */
-                widget(index)->setProperty(TAB_SYSTEM_TITLE_PROPERTY, QVariant());
-            }
-            else
-            {
-                /* Set the custom text */
-                setTabIcon(index, QIcon{});
-                setTabText(index, text);
-            }
+            /* Restore the stored title */
+            setTabIcon(index, QIcon{});
+            setTabText(index, system_title.toString());
+            /* Reset the stored title memory */
+            widget(index)->setProperty(TAB_SYSTEM_TITLE_PROPERTY, QVariant());
         }
         else
         {
-            /* Start custom title when text is no more the default value */
-            if (!text.isEmpty() && text!=previous_text)
-            {
-                /* Store the title before we set the first custom value */
-                widget(index)->setProperty(TAB_SYSTEM_TITLE_PROPERTY, previous_text);
-                /* Set the custom text */
-                setTabIcon(index, QIcon{});
-                setTabText(index, text);
-            }
-            /* else... no need to change the title */
+            /* Set the custom text */
+            setTabIcon(index, QIcon{});
+            setTabText(index, text);
         }
-        if (currentIndex() == index)
-            emit currentTitleChanged(index);
     }
+    else
+    {
+        /* Start custom title when text is no more the default value */
+        if (!text.isEmpty() && text!=previous_text)
+        {
+            /* Store the title before we set the first custom value */
+            widget(index)->setProperty(TAB_SYSTEM_TITLE_PROPERTY, previous_text);
+            /* Set the custom text */
+            setTabIcon(index, QIcon{});
+            setTabText(index, text);
+        }
+        /* else... no need to change the title */
+    }
+    if (currentIndex() == index)
+        emit currentTitleChanged(index);
+}
+
+void TabWidget::renameSession(int index)
+{
+    bool ok = false;
+    QString text = QInputDialog::getText(this, tr("Tab name"),
+                                        tr("New tab name:"), QLineEdit::Normal,
+                                        tabText(index), &ok).simplified();
+    if(ok)
+        setLabel(index, text);
 }
 
 void TabWidget::renameCurrentSession()

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -80,7 +80,7 @@ TermWidgetHolder * TabWidget::terminalHolder()
 }
 
 
-int TabWidget::addNewTab(TerminalConfig config)
+int TabWidget::addNewTab(TerminalConfig config, const QString &dbus_id)
 {
     tabNumerator++;
     QString label = QString(tr("Shell No. %1")).arg(tabNumerator);
@@ -89,7 +89,7 @@ int TabWidget::addNewTab(TerminalConfig config)
     if (ch)
         config.provideCurrentDirectory(ch->currentTerminal()->impl()->workingDirectory());
 
-    TermWidgetHolder *console = new TermWidgetHolder(config, this);
+    TermWidgetHolder *console = new TermWidgetHolder(config, dbus_id, this);
     console->setWindowTitle(label);
     connect(console, &TermWidgetHolder::finished, this, &TabWidget::removeFinished);
     connect(console, &TermWidgetHolder::lastTerminalClosed, this, &TabWidget::removeFinished);

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -52,7 +52,7 @@ public:
     bool hasRunningProcess() const;
 
 public slots:
-    int addNewTab(TerminalConfig cfg);
+    int addNewTab(TerminalConfig cfg, const QString &dbus_id = QString());
     void removeTab(int index, bool prompt = false);
     void switchTab(int);
     void onAction();

--- a/src/tabwidget.h
+++ b/src/tabwidget.h
@@ -50,6 +50,7 @@ public:
     const QList<QWidget*>& history() const;
 
     bool hasRunningProcess() const;
+    void setLabel(int, const QString&);
 
 public slots:
     int addNewTab(TerminalConfig cfg, const QString &dbus_id = QString());

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -40,6 +40,7 @@
 #include "config.h"
 #include "properties.h"
 #include "qterminalapp.h"
+#include "qterminalutils.h"
 
 static int TermWidgetCount = 0;
 
@@ -381,12 +382,29 @@ QDBusObjectPath TermWidget::splitHorizontal(const QHash<QString,QVariant> &termA
     return holder->split(this, Qt::Horizontal, cfg)->getDbusPath();
 }
 
+QDBusObjectPath TermWidget::splitHorizontal(const QString &dbus_id, const QString &shell_command, const QString &workdir, const int newPercent)
+{
+    TermWidgetHolder *holder = findParent<TermWidgetHolder>(this);
+    assert(holder != nullptr);
+    TerminalConfig cfg = TerminalConfig(workdir.isEmpty() ? QTerminalApp::Instance()->getWorkingDirectory() : workdir, parse_command(shell_command));
+    return holder->split(this, Qt::Horizontal, cfg, dbus_id, newPercent)->getDbusPath();
+}
+
 QDBusObjectPath TermWidget::splitVertical(const QHash<QString,QVariant> &termArgs)
 {
     TermWidgetHolder *holder = findParent<TermWidgetHolder>(this);
     assert(holder != nullptr);
     TerminalConfig cfg = TerminalConfig::fromDbus(termArgs, this);
     return holder->split(this, Qt::Vertical, cfg)->getDbusPath();
+}
+
+
+QDBusObjectPath TermWidget::splitVertical(const QString &dbus_id, const QString &shell_command, const QString &workdir, const int newPercent)
+{
+    TermWidgetHolder *holder = findParent<TermWidgetHolder>(this);
+    assert(holder != nullptr);
+    TerminalConfig cfg = TerminalConfig(workdir.isEmpty() ? QTerminalApp::Instance()->getWorkingDirectory() : workdir, parse_command(shell_command));
+    return holder->split(this, Qt::Vertical, cfg, dbus_id,  newPercent)->getDbusPath();
 }
 
 QDBusObjectPath TermWidget::getTab()

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -72,7 +72,18 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
             setArgs(shell);
     }
 
-    setEnvironment(QStringList(QStringLiteral("TERM=%1").arg(Properties::Instance()->term)));
+    QStringList env = QStringList() << QStringLiteral("TERM=%1").arg(Properties::Instance()->term);
+#ifdef HAVE_QDBUS
+    if (TermWidget *tw = qobject_cast<TermWidget*>(parent))
+    {
+        // this is extremely convenient for cool zsh kids who can just "qdbus ${(z)QTERM_DBUS} whatever"
+        env << QStringLiteral("QTERM_DBUS=%1 %2").arg(QTerminalApp::Instance()->getDbusService()).arg(tw->getDbusPathString())
+        // but sucks for bash lusers, so be kind and set the parts into separate variables as well
+            << QStringLiteral("QTERM_DBUS_SERVICE=%1").arg(QTerminalApp::Instance()->getDbusService())
+            << QStringLiteral("QTERM_DBUS_OBJECT=%1").arg(tw->getDbusPathString());
+    }
+#endif
+    setEnvironment(env);
 
     setMotionAfterPasting(Properties::Instance()->m_motionAfterPaste);
     disableBracketedPasteMode(Properties::Instance()->m_disableBracketedPasteMode);

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -397,4 +397,24 @@ void TermWidget::sendText(const QString& text)
     }
 }
 
+void TermWidget::setColorScheme(const QString& scheme)
+{
+    if (impl())
+    {
+        impl()->setColorScheme(scheme);
+    }
+}
+
+void TermWidget::setBackgroundImage(const QString& image, const int mode)
+{
+    if (impl())
+    {
+        if (!image.isEmpty())
+            impl()->setTerminalBackgroundImage(image);
+        if (mode > -1)
+            impl()->setTerminalBackgroundMode(mode);
+        impl()->update();
+    }
+}
+
 #endif

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -436,4 +436,32 @@ void TermWidget::setFont(const QString& font, const int pointSize)
     }
 }
 
+void TermWidget::setSize(int columns, int lines)
+{
+    if (impl())
+    {
+        // https://github.com/lxqt/qtermwidget/issues/656
+        const QWidget *terminalDisplay = nullptr;
+        for (const QWidget *kid : impl()->findChildren<QWidget*>())
+        {
+            if (kid->inherits("Konsole::TerminalDisplay"))
+            {
+                terminalDisplay = kid;
+                break;
+            }
+        }
+        if (!terminalDisplay) // not supposed, but we could not correctly control the size
+            return;
+
+        if (columns < 1)
+            columns = impl()->screenColumnsCount();
+        if (lines < 1)
+            lines = impl()->screenLinesCount();
+        impl()->setSize(QSize(columns, lines));
+
+        QSize sh = terminalDisplay->sizeHint();
+        window()->resize(window()->size() - size() + sh);
+    }
+}
+
 #endif

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -287,9 +287,9 @@ bool TermWidget::eventFilter(QObject * /*obj*/, QEvent * ev)
     return false;
 }
 
-TermWidget::TermWidget(TerminalConfig &cfg, QWidget *parent)
+TermWidget::TermWidget(TerminalConfig &cfg, const QString &dbus_id, QWidget *parent)
     : QWidget(parent)
-    , DBusAddressable(QStringLiteral("/terminals"))
+    , DBusAddressable(QStringLiteral("/terminals"), dbus_id)
     , m_term(new TermWidgetImpl(cfg, this))
     , m_layout(new QVBoxLayout)
     , m_border(palette().color(QPalette::Window))
@@ -414,6 +414,14 @@ void TermWidget::setBackgroundImage(const QString& image, const int mode)
         if (mode > -1)
             impl()->setTerminalBackgroundMode(mode);
         impl()->update();
+    }
+}
+
+void TermWidget::setFont(const QString& font, const int pointSize)
+{
+    if (impl())
+    {
+        impl()->setTerminalFont(QFont(font, pointSize < 0 ? impl()->getTerminalFont().pointSize() : pointSize));
     }
 }
 

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -88,6 +88,8 @@ class TermWidget : public QWidget, public DBusAddressable
         #ifdef HAVE_QDBUS
         QDBusObjectPath splitHorizontal(const QHash<QString,QVariant> &termArgs);
         QDBusObjectPath splitVertical(const QHash<QString,QVariant> &termArgs);
+        QDBusObjectPath splitHorizontal(const QString &dbus_id, const QString &shell_command, const QString &workdir, const int newPercent);
+        QDBusObjectPath splitVertical(const QString &dbus_id, const QString &shell_command, const QString &workdir, const int newPercent);
         QDBusObjectPath getTab();
         void sendText(const QString& text);
         void closeTerminal();

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -91,6 +91,8 @@ class TermWidget : public QWidget, public DBusAddressable
         QDBusObjectPath getTab();
         void sendText(const QString& text);
         void closeTerminal();
+        void setColorScheme(const QString& scheme);
+        void setBackgroundImage(const QString &image, const int mode);
         #endif
 
         bool eventFilter(QObject * obj, QEvent * evt) override;

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -78,7 +78,7 @@ class TermWidget : public QWidget, public DBusAddressable
     QColor m_border;
 
     public:
-        TermWidget(TerminalConfig &cfg, QWidget * parent=nullptr);
+        TermWidget(TerminalConfig &cfg, const QString &dbus_id = QString(), QWidget * parent=nullptr);
 
         void propertiesChanged();
         QStringList availableKeyBindings() { return m_term->availableKeyBindings(); }
@@ -93,6 +93,7 @@ class TermWidget : public QWidget, public DBusAddressable
         void closeTerminal();
         void setColorScheme(const QString& scheme);
         void setBackgroundImage(const QString &image, const int mode);
+        void setFont(const QString& font, const int pointSize);
         #endif
 
         bool eventFilter(QObject * obj, QEvent * evt) override;

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -94,6 +94,7 @@ class TermWidget : public QWidget, public DBusAddressable
         void setColorScheme(const QString& scheme);
         void setBackgroundImage(const QString &image, const int mode);
         void setFont(const QString& font, const int pointSize);
+        void setSize(int cloumns, int lines);
         #endif
 
         bool eventFilter(QObject * obj, QEvent * evt) override;

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -460,5 +460,13 @@ void TermWidgetHolder::closeTab()
     Q_EMIT parent->tabCloseRequested(idx);
 }
 
+void TermWidgetHolder::setLabel(const QString &label)
+{
+    TabWidget *parent = findParent<TabWidget>(this);
+    int idx = parent->indexOf(this);
+    assert(idx != -1);
+    parent->setLabel(idx, label);
+}
+
 #endif
 

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -53,7 +53,7 @@ TermWidgetHolder::TermWidgetHolder(TerminalConfig &config, QWidget * parent)
 
     QSplitter *s = new QSplitter(this);
     s->setFocusPolicy(Qt::NoFocus);
-    TermWidget *w = newTerm(config);
+    TermWidget *w = newTerm(config, dbus_id);
     s->addWidget(w);
     lay->addWidget(s);
     m_currentTerm = w;
@@ -355,9 +355,9 @@ TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientati
     return w;
 }
 
-TermWidget *TermWidgetHolder::newTerm(TerminalConfig &cfg)
+TermWidget *TermWidgetHolder::newTerm(TerminalConfig &cfg, const QString &dbus_id)
 {
-    TermWidget *w = new TermWidget(cfg, this);
+    TermWidget *w = new TermWidget(cfg, dbus_id, this);
     // proxy signals
     connect(w, &TermWidget::renameSession, this, &TermWidgetHolder::renameSession);
     connect(w, &TermWidget::removeCurrentSession, this, &TermWidgetHolder::lastTerminalClosed);

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -36,10 +36,10 @@
 #include <utility>
 
 
-TermWidgetHolder::TermWidgetHolder(TerminalConfig &config, QWidget * parent)
+TermWidgetHolder::TermWidgetHolder(TerminalConfig &config, const QString &dbus_id, QWidget * parent)
     : QWidget(parent)
       #ifdef HAVE_QDBUS
-      , DBusAddressable(QStringLiteral("/tabs"))
+      , DBusAddressable(QStringLiteral("/tabs"), dbus_id)
       #endif
 {
     #ifdef HAVE_QDBUS

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -327,7 +327,7 @@ void TermWidgetHolder::splitCollapse(TermWidget * term)
         emit finished();
 }
 
-TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation, TerminalConfig cfg)
+TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientation, TerminalConfig cfg, const QString &dbus_id, int newPercent)
 {
     QSplitter *parent = qobject_cast<QSplitter *>(term->parent());
     assert(parent);
@@ -336,7 +336,7 @@ TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientati
     QList<int> parentSizes = parent->sizes();
 
     QList<int> sizes;
-    sizes << 1 << 1;
+    sizes << 100 - newPercent << newPercent;
 
     QSplitter *s = new QSplitter(orientation, this);
     s->setFocusPolicy(Qt::NoFocus);
@@ -344,7 +344,7 @@ TermWidget * TermWidgetHolder::split(TermWidget *term, Qt::Orientation orientati
 
     cfg.provideCurrentDirectory(term->impl()->workingDirectory());
 
-    TermWidget * w = newTerm(cfg);
+    TermWidget * w = newTerm(cfg, dbus_id);
     s->insertWidget(1, w);
     s->setSizes(sizes);
 

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -72,6 +72,7 @@ class TermWidgetHolder : public QWidget
         QList<QDBusObjectPath> getTerminals();
         QDBusObjectPath getWindow();
         void closeTab();
+        void setLabel(const QString &label);
         #endif
 
 

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -97,7 +97,7 @@ class TermWidgetHolder : public QWidget
         TermWidget * m_currentTerm;
 
         void split(TermWidget * term, Qt::Orientation orientation);
-        TermWidget * newTerm(TerminalConfig &cfg);
+        TermWidget * newTerm(TerminalConfig &cfg, const QString &dbus_id = QString());
 
     private slots:
         void setCurrentTerminal(TermWidget* term);

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -51,7 +51,7 @@ class TermWidgetHolder : public QWidget
     Q_OBJECT
 
     public:
-        TermWidgetHolder(TerminalConfig &cfg, QWidget * parent=nullptr);
+        TermWidgetHolder(TerminalConfig &cfg, const QString &dbus_id = QString(), QWidget * parent=nullptr);
         ~TermWidgetHolder() override;
 
         void propertiesChanged();

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -63,7 +63,7 @@ class TermWidgetHolder : public QWidget
         void zoomOut(uint step);
 
         TermWidget* currentTerminal();
-        TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg);
+        TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg, const QString &dbus_id = QString(), int newPercent = 50);
 
         bool hasRunningProcess() const;
 


### PR DESCRIPTION
QTerminal has a dbus interface but it's of extremely limited use.

This series of patches adds some **methods to control the terminal look and feel via dbus** (there's already a sendText function, so this should be no security concern), methods to **create new windows and tabs that are usable via qdbus** (which does not support QVariantMap) and allows **scriptable access** to the dbus address, either by **predetermining service and object path** resp. also by exporting those into the **clients environment**.

This allows to control special terminals (running mutt, top or your qnd shell) to be accessed via keyboard shortcuts, create new windows and tabs and distinguish them by color, font or background image, change between bright and dark schemes on the fly (for daytime awareness) and stuff that I haven't figured yet (but because sendText is unfiltered for newlines you should theoretically be able to remote control mutt for mailto: links - now that you know which terminal runs mutt ;)


~There's likely **requirement for fix-up**, because the present **coding style** is all over the place and I forgot what the preferred one is :)
CONTRIBUTING.md might benefit from addressing that *cough*~

Also it's not strictly required but you might prefer to hide API and command switch behind the preprocessor token.

Also
https://github.com/lxqt/qterminal/issues/1123
https://github.com/lxqt/qtermwidget/issues/507
https://github.com/lxqt/qterminal/issues/812
https://github.com/lxqt/qterminal/issues/980
https://github.com/lxqt/qterminal/issues/301 (but that's technically unrelated and a QTermWidget deficiency)

Todo:
~set tab (and window?) titles (`printf "\033]0;%s\007" "foobar"`usually doesn't work because the shell will reset it)
make splitting more accessible (qdbus compatible and immediate proportion control)
size parameter for new instance (might also make sense for newWindow to allow informed window placement), https://github.com/lxqt/qterminal/issues/531~