### PR TITLE
Cleanup shortcuts GUI in Prefs → Dropdown

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -1057,7 +1057,7 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
         </widget>
        </item>
        <item>
-        <layout class="QFormLayout" name="dropShortCutFormLayout">
+        <layout class="QFormLayout" name="shortCutFormLayout">
          <item row="0" column="0">
           <widget class="QLabel" name="dropShortCutLabel">
            <property name="text">
@@ -1065,40 +1065,20 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
            </property>
           </widget>
          </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QLabel" name="waylandLabel">
-         <property name="text">
-          <string>Note: On Wayland, the shortcut has to be added in the compositor settings for 'qterminal -d'.</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Policy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>10</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QFormLayout" name="lockShortCutFormLayout">
-         <item row="0" column="0">
+         <item row="1" column="0">
           <widget class="QLabel" name="lockShortCutLabel">
            <property name="text">
             <string>Lock shortcut:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QLabel" name="waylandLabel">
+           <property name="text">
+            <string>Note: On Wayland, the shortcuts have to be added in the compositor settings, for e.g. "qterminal -d".</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -1065,20 +1065,20 @@ To remove/disable a Shortcut, at point 2 press only a modifier (like Shift)</str
            </property>
           </widget>
          </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="lockShortCutLabel">
-           <property name="text">
-            <string>Lock shortcut:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0" colspan="2">
+         <item row="1" column="0" colspan="2">
           <widget class="QLabel" name="waylandLabel">
            <property name="text">
-            <string>Note: On Wayland, the shortcuts have to be added in the compositor settings, for e.g. "qterminal -d".</string>
+            <string>Note: On Wayland, the shortcut has to be added in the compositor settings for 'qterminal -d'.</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lockShortCutLabel">
+           <property name="text">
+            <string>Lock shortcut:</string>
            </property>
           </widget>
          </item>

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -279,7 +279,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropShortCutEdit->setClearButtonEnabled(true);
 
     lockShortCutEdit = new KeySequenceEdit();
-    shortCutFormLayout->setWidget(1, QFormLayout::FieldRole, lockShortCutEdit);
+    shortCutFormLayout->setWidget(2, QFormLayout::FieldRole, lockShortCutEdit);
     lockShortCutEdit->installEventFilter(this);
     lockShortCutEdit->setKeySequence(Properties::Instance()->dropLockShortCut);
     lockShortCutEdit->setClearButtonEnabled(true);
@@ -321,8 +321,6 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     waylandLabel->setVisible(onWayland);
     dropShortCutLabel->setEnabled(!onWayland);
     dropShortCutEdit->setEnabled(!onWayland);
-    lockShortCutLabel->setEnabled(!onWayland);
-    lockShortCutEdit->setEnabled(!onWayland);
 
     // restore its size while fitting it into available desktop geometry
     QSize s;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -273,14 +273,16 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     dropWidthSpinBox->setValue(Properties::Instance()->dropWidth);
 
     dropShortCutEdit = new KeySequenceEdit();
-    dropShortCutFormLayout->setWidget(0, QFormLayout::FieldRole, dropShortCutEdit);
+    shortCutFormLayout->setWidget(0, QFormLayout::FieldRole, dropShortCutEdit);
     dropShortCutEdit->installEventFilter(this);
     dropShortCutEdit->setKeySequence(Properties::Instance()->dropShortCut);
+    dropShortCutEdit->setClearButtonEnabled(true);
 
     lockShortCutEdit = new KeySequenceEdit();
-    lockShortCutFormLayout->setWidget(0, QFormLayout::FieldRole, lockShortCutEdit);
+    shortCutFormLayout->setWidget(1, QFormLayout::FieldRole, lockShortCutEdit);
     lockShortCutEdit->installEventFilter(this);
     lockShortCutEdit->setKeySequence(Properties::Instance()->dropLockShortCut);
+    lockShortCutEdit->setClearButtonEnabled(true);
 
     useBookmarksCheckBox->setChecked(Properties::Instance()->useBookmarks);
     bookmarksLineEdit->setText(Properties::Instance()->bookmarksFile); // also needed by openBookmarksFile()
@@ -319,6 +321,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     waylandLabel->setVisible(onWayland);
     dropShortCutLabel->setEnabled(!onWayland);
     dropShortCutEdit->setEnabled(!onWayland);
+    lockShortCutLabel->setEnabled(!onWayland);
+    lockShortCutEdit->setEnabled(!onWayland);
 
     // restore its size while fitting it into available desktop geometry
     QSize s;


### PR DESCRIPTION
- Put `dropShortCut{Label,Edit}`, `lockShortCut{Label,Edit}`, `waylandLabel` in the same form layout
- Enable for `{drop,lock}ShortCutEdit` a clear button
- ~Disable `lockShortCut{Label,Edit}` on Wayland too~