### PR TITLE
silence notification

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -855,13 +855,20 @@
                </widget>
               </item>
               <item row="12" column="0" colspan="2">
+               <widget class="QCheckBox" name="notifySilenceCheckBox">
+                <property name="text">
+                 <string>Notify when output stops in minimized windows</string>
+                </property>
+               </widget>
+              </item>
+              <item row="13" column="0" colspan="2">
                <widget class="QCheckBox" name="useCwdCheckBox">
                 <property name="text">
                  <string>Open new terminals in current working directory</string>
                 </property>
                </widget>
               </item>
-              <item row="13" column="0" colspan="2">
+              <item row="14" column="0" colspan="2">
                <widget class="QCheckBox" name="openNewTabRightToActiveTabCheckBox">
                 <property name="toolTip">
                  <string>If unchecked the new tab will be opened as the rightmost tab</string>
@@ -871,21 +878,21 @@
                 </property>
                </widget>
               </item>
-              <item row="14" column="0">
+              <item row="15" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
                 </property>
                </widget>
               </item>
-              <item row="15" column="0">
+              <item row="16" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="15" column="1">
+              <item row="16" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -911,10 +918,10 @@
                 </item>
                </widget>
               </item>
-              <item row="16" column="1">
+              <item row="17" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
-              <item row="16" column="0">
+              <item row="17" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -152,6 +152,7 @@ void Properties::loadSettings()
     useCWD = m_settings->value(QLatin1String("UseCWD"), true).toBool();
     m_openNewTabRightToActiveTab = m_settings->value(QLatin1String("OpenNewTabRightToActiveTab"), false).toBool();
     audibleBell = m_settings->value(QLatin1String("AudibleBell"), false).toBool();
+    notifySilence = m_settings->value(QLatin1String("NotifySilence"), false).toBool();
     term = m_settings->value(QLatin1String("Term"), QLatin1String("xterm-256color")).toString();
     handleHistoryCommand = m_settings->value(QLatin1String("HandleHistory")).toString();
 
@@ -292,6 +293,7 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("UseCWD"), useCWD);
     m_settings->setValue(QLatin1String("OpenNewTabRightToActiveTab"), m_openNewTabRightToActiveTab);
     m_settings->setValue(QLatin1String("AudibleBell"), audibleBell);
+    m_settings->setValue(QLatin1String("NotifySilence"), notifySilence);
     m_settings->setValue(QLatin1String("Term"), term);
     m_settings->setValue(QLatin1String("HandleHistory"), handleHistoryCommand);
 

--- a/src/properties.h
+++ b/src/properties.h
@@ -106,6 +106,7 @@ class Properties
         bool m_openNewTabRightToActiveTab;
 
         bool audibleBell;
+        bool notifySilence;
 
         QString term;
 

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -258,6 +258,12 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     audibleBellCheckBox->setEnabled(false);
 #endif
 
+#ifdef HAVE_QDBUS
+    notifySilenceCheckBox->setChecked(Properties::Instance()->notifySilence);
+#else
+    notifySilenceCheckBox->setEnabled(false);
+#endif
+
     termComboBox->setCurrentText(Properties::Instance()->term);
 
     handleHistoryLineEdit->setText(Properties::Instance()->handleHistoryCommand);
@@ -374,6 +380,12 @@ void PropertiesDialog::apply()
     Properties::Instance()->audibleBell = audibleBellCheckBox->isChecked();
 #else
     Properties::Instance()->audibleBell = false;
+#endif
+
+#ifdef HAVE_QDBUS
+    Properties::Instance()->notifySilence = notifySilenceCheckBox->isChecked();
+#else
+    Properties::Instance()->notifySilence = false;
 #endif
 
     Properties::Instance()->term = termComboBox->currentText();

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -26,6 +26,8 @@
 #include <cassert>
 
 #ifdef HAVE_QDBUS
+    #include <QTabWidget>
+    #include <QWindow>
     #include <QtDBus/QtDBus>
     #include "termwidgetholder.h"
     #include "terminaladaptor.h"
@@ -300,6 +302,10 @@ bool TermWidget::eventFilter(QObject * /*obj*/, QEvent * ev)
     {
         impl()->setFocus();
     }
+    else if (ev->type() == QEvent::KeyRelease)
+    {
+        m_activityClock.start();
+    }
     return false;
 }
 
@@ -309,6 +315,7 @@ TermWidget::TermWidget(TerminalConfig &cfg, const QString &dbus_id, QWidget *par
     , m_term(new TermWidgetImpl(cfg, this))
     , m_layout(new QVBoxLayout)
     , m_border(palette().color(QPalette::Window))
+    , m_silenceNotification(0)
 {
 
     #ifdef HAVE_QDBUS
@@ -347,11 +354,35 @@ void TermWidget::propertiesChanged()
     else
         m_layout->setContentsMargins(0, 0, 0, 0);
 
+    m_term->setMonitorActivity(Properties::Instance()->notifySilence);
+    if (Properties::Instance()->notifySilence)
+    {
+        connect(m_term, &QTermWidget::silence, this, &TermWidget::notifySilence, Qt::UniqueConnection);
+        // this is to limit the notification to events after prolonged activity and
+        // withdraw the notification if the terminal re-activates by itself
+        connect(m_term, &QTermWidget::activity, this, &TermWidget::notifyActiviy, Qt::UniqueConnection);
+    }
+    else
+    {
+        disconnect(m_term, &QTermWidget::silence, this, &TermWidget::notifySilence);
+        disconnect(m_term, &QTermWidget::activity, this, &TermWidget::notifyActiviy);
+    }
+
     m_term->propertiesChanged();
 }
 
+#define NOTIFICATION_INTERFACE QStringLiteral("org.freedesktop.Notifications"), QStringLiteral("/org/freedesktop/Notifications"), QStringLiteral("org.freedesktop.Notifications")
+
 void TermWidget::term_termGetFocus()
 {
+    if (m_silenceNotification)
+    {
+#ifdef HAVE_QDBUS
+        QDBusInterface notifications( NOTIFICATION_INTERFACE );
+        notifications.callWithArgumentList(QDBus::NoBlock, QStringLiteral("CloseNotification"), QList<QVariant>() << m_silenceNotification);
+#endif
+        m_silenceNotification = 0;
+    }
     m_border = palette().color(QPalette::Highlight);
     emit termGetFocus(this);
     update();
@@ -376,7 +407,101 @@ void TermWidget::paintEvent (QPaintEvent *)
     }
 }
 
-#if HAVE_QDBUS
+void TermWidget::notifySilence()
+{
+    if (m_activityClock.elapsed() < 45 * 1000)
+        return; // don't care about short term jobs
+    if (isActiveWindow())
+        return; //the user probably got that alright
+    bool visible = isVisible();
+    if (visible && window()->windowHandle())
+        visible = window()->windowHandle()->isExposed(); // for wayland and minimized windows
+
+    if (visible)
+    {
+        QApplication::alert(this);
+        return; // only notify for hidden windows
+    }
+
+#ifndef HAVE_QDBUS
+    // at least alert
+    QApplication::alert(this);
+#else
+    QList<QVariant> vl;
+    QVariantMap hints;
+    hints[QStringLiteral("transient")] = true; // don't log this notification
+    hints[QStringLiteral("urgency")] = 0; // low urgency
+
+    QImage screenshot(qMin(512,width()), qMin(256,height()), QImage::Format_RGB888);
+    QRect corner = screenshot.rect();
+    corner.moveBottomLeft(rect().bottomLeft());
+    render(&screenshot, QPoint(), corner);
+    QDBusArgument iiibiiay;
+    iiibiiay.beginStructure();
+    iiibiiay << screenshot.width();
+    iiibiiay << screenshot.height();
+    iiibiiay << screenshot.bytesPerLine();
+    iiibiiay << screenshot.hasAlphaChannel();
+    iiibiiay << 8; // bits per sample
+    iiibiiay << 3; // channels - RGB
+    iiibiiay << QByteArray(screenshot.constBits());
+    iiibiiay.endStructure();
+    hints[QStringLiteral("image-data")] = QVariant::fromValue(iiibiiay); // screenshot
+
+    QString body = window()->windowTitle();
+    if (TermWidgetHolder *holder = findParent<TermWidgetHolder>(this))
+        body = holder->label();
+    QStringList actions;
+    if (qApp->platformName() != QStringLiteral("wayland")) // wayland sucks™, https://github.com/lxqt/qterminal/pull/1359
+        actions << QStringLiteral("show") << QStringLiteral("Show Me!");
+    // vl <<  << summary << body << actions << hints << timeout;
+    vl  << QStringLiteral("QTerminal") << m_silenceNotification << QStringLiteral("qterminal") // appName << id << appIcon
+        << tr("Output ended") << body << actions << hints << 0 /*forever, until we close it*/;
+    QDBusInterface notifications( NOTIFICATION_INTERFACE );
+    QDBusReply<uint> reply = notifications.callWithArgumentList(QDBus::Block, QStringLiteral("Notify"), vl);
+    if (reply.isValid())
+    {
+        m_silenceNotification = reply.value();
+        QDBusConnection::sessionBus().connect(NOTIFICATION_INTERFACE, QStringLiteral("ActionInvoked"), this, SLOT(handleNotificationAction(uint, QString)));
+    }
+}
+
+void TermWidget::handleNotificationAction(uint id, QString action)
+{
+    if (id != m_silenceNotification)
+        return;
+    if (action == QStringLiteral("show"))
+    {
+        emit termGetFocus(this);
+        if (TermWidgetHolder *holder = findParent<TermWidgetHolder>(this))
+            if (QTabWidget *tabs = findParent<QTabWidget>(this))
+                tabs->setCurrentWidget(holder);
+        QWidget *win = window();
+        if (QWindow *handle = win->windowHandle())
+            handle->setWindowStates(handle->windowStates() & ~Qt::WindowMinimized);
+        win->show();
+        win->activateWindow();
+        win->raise();
+    }
+}
+
+#endif
+
+void TermWidget::notifyActiviy()
+{
+    m_activityClock.start();
+    if (m_silenceNotification)
+    {
+#ifdef HAVE_QDBUS
+        QDBusInterface notifications( NOTIFICATION_INTERFACE );
+        notifications.callWithArgumentList(QDBus::NoBlock, QStringLiteral("CloseNotification"), QList<QVariant>() << m_silenceNotification);
+#endif
+        m_silenceNotification = 0;
+    }
+    m_term->setMonitorSilence(true);
+}
+
+#ifdef HAVE_QDBUS
 
 QDBusObjectPath TermWidget::splitHorizontal(const QHash<QString,QVariant> &termArgs)
 {

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -76,6 +76,8 @@ class TermWidget : public QWidget, public DBusAddressable
     TermWidgetImpl * m_term;
     QVBoxLayout * m_layout;
     QColor m_border;
+    QElapsedTimer m_activityClock;
+    uint m_silenceNotification;
 
     public:
         TermWidget(TerminalConfig &cfg, const QString &dbus_id = QString(), QWidget * parent=nullptr);
@@ -123,6 +125,11 @@ class TermWidget : public QWidget, public DBusAddressable
     private slots:
         void term_termGetFocus();
         void term_termLostFocus();
+        void notifySilence();
+        void notifyActiviy();
+        #ifdef HAVE_QDBUS
+        void handleNotificationAction(uint id, QString action);
+        #endif
 };
 
 #endif

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -425,6 +425,16 @@ bool TermWidgetHolder::hasRunningProcess() const
     return false;
 }
 
+QString TermWidgetHolder::label() const
+{
+    if (TabWidget *parent = findParent<TabWidget>(const_cast<TermWidgetHolder*>(this)))
+    {
+        int idx = parent->indexOf(this);
+        return idx > -1 ? parent->tabText(idx) : QString();
+    }
+    return QString();
+}
+
 #ifdef HAVE_QDBUS
 
 QDBusObjectPath TermWidgetHolder::getActiveTerminal()

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -62,6 +62,7 @@ class TermWidgetHolder : public QWidget
         void zoomIn(uint step);
         void zoomOut(uint step);
 
+        QString label() const;
         TermWidget* currentTerminal();
         TermWidget* split(TermWidget * term, Qt::Orientation orientation, TerminalConfig cfg, const QString &dbus_id = QString(), int newPercent = 50);
 


### PR DESCRIPTION
Got curious about https://github.com/lxqt/qterminal/issues/480
Preliminary patch, I guess it should be configurable.

```for ((i=0;i<10;++i)); do echo $i; sleep 1; done``` and hide the terminal
You should™ get a notification after ~20 total (10s for the script, 10 for the silence detection)
Activating the terminal either way (conveniently through the notification if your daemon supports actions) should™ implicitly hide the notification.

Do we want this at all?

Considerations:
1. config option (should be obvious but I spent way too much time on this anyway :smile: )
2. after showing the notification, monitor for activity and hide it again (not sure whether this can run into conflicts w/ the timeouts) in case some long term process stalls > 10s and then continues.