### PR TITLE
implement visual bell

### DIFF
--- a/src/forms/propertiesdialog.ui
+++ b/src/forms/propertiesdialog.ui
@@ -872,20 +872,27 @@
                </widget>
               </item>
               <item row="14" column="0">
+               <widget class="QCheckBox" name="visualBellCheckBox">
+                <property name="text">
+                 <string>Visual bell</string>
+                </property>
+               </widget>
+              </item>
+              <item row="15" column="0">
                <widget class="QCheckBox" name="audibleBellCheckBox">
                 <property name="text">
                  <string>Audible bell</string>
                 </property>
                </widget>
               </item>
-              <item row="15" column="0">
+              <item row="16" column="0">
                <widget class="QLabel" name="label_14">
                 <property name="text">
                  <string>Default $TERM</string>
                 </property>
                </widget>
               </item>
-              <item row="15" column="1">
+              <item row="16" column="1">
                <widget class="QComboBox" name="termComboBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -911,10 +918,10 @@
                 </item>
                </widget>
               </item>
-              <item row="16" column="1">
+              <item row="17" column="1">
                <widget class="QLineEdit" name="handleHistoryLineEdit"/>
               </item>
-              <item row="16" column="0">
+              <item row="17" column="0">
                <widget class="QLabel" name="label_17">
                 <property name="toolTip">
                  <string>This command will be run with an argument containing the file name of a tempfile containing the scrollback history

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -151,6 +151,8 @@ void Properties::loadSettings()
     saveStateOnExit = m_settings->value(QLatin1String("SaveStateOnExit"), true).toBool();
     useCWD = m_settings->value(QLatin1String("UseCWD"), true).toBool();
     m_openNewTabRightToActiveTab = m_settings->value(QLatin1String("OpenNewTabRightToActiveTab"), false).toBool();
+    visualBellColor = m_settings->value(QLatin1String("VisualBellColor"), QLatin1String("0x990000")).toString().toInt(nullptr, 16);
+    visualBell = m_settings->value(QLatin1String("VisualBell"), false).toBool();
     audibleBell = m_settings->value(QLatin1String("AudibleBell"), false).toBool();
     term = m_settings->value(QLatin1String("Term"), QLatin1String("xterm-256color")).toString();
     handleHistoryCommand = m_settings->value(QLatin1String("HandleHistory")).toString();
@@ -291,6 +293,8 @@ void Properties::saveSettings()
     m_settings->setValue(QLatin1String("SaveStateOnExit"), saveStateOnExit);
     m_settings->setValue(QLatin1String("UseCWD"), useCWD);
     m_settings->setValue(QLatin1String("OpenNewTabRightToActiveTab"), m_openNewTabRightToActiveTab);
+    m_settings->setValue(QLatin1String("VisualBellColor"), QString::number(visualBellColor,16));
+    m_settings->setValue(QLatin1String("VisualBell"), visualBell);
     m_settings->setValue(QLatin1String("AudibleBell"), audibleBell);
     m_settings->setValue(QLatin1String("Term"), term);
     m_settings->setValue(QLatin1String("HandleHistory"), handleHistoryCommand);

--- a/src/properties.h
+++ b/src/properties.h
@@ -105,6 +105,8 @@ class Properties
         bool useCWD;
         bool m_openNewTabRightToActiveTab;
 
+        QRgb visualBellColor;
+        bool visualBell;
         bool audibleBell;
 
         QString term;

--- a/src/propertiesdialog.cpp
+++ b/src/propertiesdialog.cpp
@@ -252,6 +252,7 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     useCwdCheckBox->setChecked(Properties::Instance()->useCWD);
     openNewTabRightToActiveTabCheckBox->setChecked(Properties::Instance()->m_openNewTabRightToActiveTab);
 
+    visualBellCheckBox->setChecked(Properties::Instance()->visualBell);
 #ifdef HAVE_LIBCANBERRA
     audibleBellCheckBox->setChecked(Properties::Instance()->audibleBell);
 #else
@@ -370,6 +371,7 @@ void PropertiesDialog::apply()
 
     Properties::Instance()->useCWD = useCwdCheckBox->isChecked();
     Properties::Instance()->m_openNewTabRightToActiveTab = openNewTabRightToActiveTabCheckBox->isChecked();
+    Properties::Instance()->visualBell = visualBellCheckBox->isChecked();
 #ifdef HAVE_LIBCANBERRA
     Properties::Instance()->audibleBell = audibleBellCheckBox->isChecked();
 #else

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -23,6 +23,7 @@
 #include <QMessageBox>
 #include <QAbstractButton>
 #include <QMouseEvent>
+#include <QGraphicsEffect>
 #include <cassert>
 
 #ifdef HAVE_QDBUS
@@ -260,7 +261,52 @@ void TermWidgetImpl::activateUrl(const QUrl & url, bool fromContextMenu) {
     }
 }
 
+class BloodShot : public QGraphicsEffect
+{
+    public:
+        BloodShot(QObject *parent = nullptr) : QGraphicsEffect(parent) {}
+    protected:
+        virtual void draw(QPainter *painter) override
+        {
+            QPoint offset;
+            const QPixmap pixmap = sourcePixmap(Qt::DeviceCoordinates, &offset);
+            if (pixmap.isNull())
+                return;
+            QTransform restoreTransform = painter->worldTransform();
+            painter->setWorldTransform(QTransform());
+            painter->drawPixmap(offset, pixmap);
+            painter->setPen(Qt::NoPen);
+            QRectF rect = sourceBoundingRect(Qt::DeviceCoordinates);
+            rect.translate(offset);
+            QRadialGradient rg(rect.center(), qMax(rect.width(), rect.height())/2.0f);
+            QColor blood(Properties::Instance()->visualBellColor);
+            blood.setAlpha(0);
+            rg.setColorAt(0, blood);
+            blood.setAlpha(200);
+            rg.setColorAt(1, blood);
+            painter->fillRect(rect, rg);
+            painter->setWorldTransform(restoreTransform);
+        }
+};
+
 void TermWidgetImpl::bell() {
+    if (Properties::Instance()->visualBell) {
+        QWidget *terminalDisplay = nullptr;
+        for (QObject *kid : children())
+        {
+            if (kid->isWidgetType() && kid->inherits("Konsole::TerminalDisplay"))
+            {
+                terminalDisplay = qobject_cast<QWidget*>(kid);
+                break;
+            }
+        }
+        if (terminalDisplay)
+        {
+            BloodShot *bang = new BloodShot(terminalDisplay);
+            terminalDisplay->setGraphicsEffect(bang);
+            QTimer::singleShot(150, this, [=]() { delete bang; });
+        }
+    }
     if (Properties::Instance()->audibleBell) {
 #ifdef HAVE_LIBCANBERRA
         if (!libcanberra_context) {


### PR DESCRIPTION
https://github.com/lxqt/qterminal/issues/1356

So here's a POC for the approach that does not require an (aligned) API update of qtermwidget.
Since the graphicseffect approach also means I get to do whatever I want, I want a bloodshot (like in FP shooters :))

The final implementation would probably use the red of the color scheme and also be configurable (if one prefers only an audible or no bell), for now this is RFC on the topic.