### PR TITLE
delay startShellProgram()

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -82,6 +82,9 @@ MainWindow::MainWindow(TerminalConfig &cfg,
     setAttribute(Qt::WA_NoSystemBackground, false);
     setAttribute(Qt::WA_DeleteOnClose);
 
+    // see ::showEvent()
+    setProperty("terminal_size_pending", true);
+
     setupUi(this);
 
     // Allow insane small sizes - reason:
@@ -960,6 +963,10 @@ void MainWindow::showEvent(QShowEvent* event)
             twl.at(0)->setSize(m_initialSize.width(), m_initialSize.height());
         m_initialSize = QSize();
     }
+
+    // unconditionally here. QTabWidget lays out lazily and the (initial) terminal
+    // must know when this is done - ideally after the user specified size is set above
+    setProperty("terminal_size_pending", false);
 
     QMainWindow::showEvent(event);
 }

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -47,6 +47,7 @@ static int TermWidgetCount = 0;
 
 TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     : QTermWidget(0, parent)
+    , scheduledShellProgramStart(false)
 #ifdef HAVE_LIBCANBERRA
     , libcanberra_context(nullptr)
 #endif
@@ -105,7 +106,10 @@ TermWidgetImpl::TermWidgetImpl(TerminalConfig &cfg, QWidget * parent)
     connect(this, &QTermWidget::urlActivated, this, &TermWidgetImpl::activateUrl);
     connect(this, &QTermWidget::bell, this, &TermWidgetImpl::bell);
 
-    startShellProgram();
+    scheduledShellProgramStart = window()->property("terminal_size_pending").toBool();
+    if (!scheduledShellProgramStart) {
+        QTimer::singleShot(0, this, &TermWidgetImpl::startShellProgram);
+    }
 }
 
 TermWidgetImpl::~TermWidgetImpl()
@@ -115,6 +119,21 @@ TermWidgetImpl::~TermWidgetImpl()
         ca_context_destroy (libcanberra_context);
     }
 #endif
+}
+
+void TermWidgetImpl::showEvent(QShowEvent *se)
+{
+    if (scheduledShellProgramStart)
+    {
+        QTimer::singleShot(0, this, [=,this]()
+        {
+            scheduledShellProgramStart = window()->property("terminal_size_pending").toBool();
+            if (!scheduledShellProgramStart) {
+                QTimer::singleShot(0, this, &TermWidgetImpl::startShellProgram);
+            }
+        });
+    }
+    QTermWidget::showEvent(se);
 }
 
 void TermWidgetImpl::propertiesChanged()

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -57,12 +57,16 @@ class TermWidgetImpl : public QTermWidget
         void zoomReset();
         void customContextMenuCall(const QPoint & pos);
 
+    protected:
+        void showEvent(QShowEvent *event);
+
     private slots:
         void activateUrl(const QUrl& url, bool fromContextMenu);
         void bell();
 
     private:
         bool m_hasCommand;
+        bool scheduledShellProgramStart;
 #ifdef HAVE_LIBCANBERRA
         ca_context* libcanberra_context;
 #endif


### PR DESCRIPTION
Unfortunately not Q_INVOCABLE so singleShot(0) hack over re-implementing the function to only call its super

relates to #899
It fixes the missing ${COLUMNS}x${LINES} but I could not reproduce the "text overwritten" part, so idk whether that's fixed

indirectly relates to https://github.com/lxqt/qtermwidget/issues/480

For reference also https://bugs.kde.org/show_bug.cgi?id=516491

---------------

This isn't purely cosmetic since some clients require specific (minimum) sizes and will either falsely refuse to start or falsely start and misbehave if they check fast enough™ (this is inherently a race condition between the shell process and qterminal resizing the terminal display)
I've not test this w/ splitters which might introduce further delay for the splitter lazily resizing the terminal.