### PR TITLE
Pick ups

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1129,6 +1129,8 @@ void MainWindow::activateOrHide()
     }
     else
     {
+        if (QWindow *win = windowHandle())
+            win->setWindowStates(win->windowStates() & ~Qt::WindowMinimized);
         show();
         activateWindow();
         raise();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -632,6 +632,7 @@ bool MainWindow::closePrompt(const QString &title, const QString &text)
     QDialog * dia = new QDialog(this);
     dia->setObjectName(QStringLiteral("exitDialog"));
     dia->setWindowTitle(title);
+    dia->setWindowModality(Qt::WindowModal);
 
     QDialogButtonBox * buttonBox = new QDialogButtonBox(QDialogButtonBox::Yes | QDialogButtonBox::No, Qt::Horizontal, dia);
     buttonBox->button(QDialogButtonBox::No)->setDefault(true);

--- a/src/org.lxqt.QTerminal.Tab.xml
+++ b/src/org.lxqt.QTerminal.Tab.xml
@@ -11,6 +11,7 @@
     <method name="getWindow">
       <arg name="window" type="o" direction="out"/>
     </method>
+    <method name="activateTab"/>
     <method name="closeTab"/>
     <method name="setLabel">
       <arg name="label" type="s" direction="in"/>

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -49,6 +49,15 @@
       <arg name="columns" type="i" direction="in"/>
       <arg name="lines" type="i" direction="in"/>
     </method>
+    <method name="hasFocus">
+      <arg name="terminal" type="b" direction="out"/>
+    </method>
+    <method name="isActiveWindow">
+      <arg name="terminal" type="b" direction="out"/>
+    </method>
+    <method name="isExposed">
+      <arg name="terminal" type="b" direction="out"/>
+    </method>
   </interface>
 </node>
 

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -32,6 +32,7 @@
     <method name="sendText">
         <arg name="text" type="s" direction="in"/>
     </method>
+    <method name="activateTerminal"/>
     <method name="closeTerminal"/>
     <method name="setColorScheme">
       <arg name="text" type="s" direction="in"/>

--- a/src/org.lxqt.QTerminal.Terminal.xml
+++ b/src/org.lxqt.QTerminal.Terminal.xml
@@ -35,15 +35,15 @@
     <method name="activateTerminal"/>
     <method name="closeTerminal"/>
     <method name="setColorScheme">
-      <arg name="text" type="s" direction="in"/>
+      <arg name="scheme_name" type="s" direction="in"/>
     </method>
     <method name="setBackgroundImage">
       <arg name="file" type="s" direction="in"/>
       <arg name="mode" type="i" direction="in"/>
     </method>
     <method name="setFont">
-      <arg name="text" type="s" direction="in"/>
-      <arg name="text" type="i" direction="in"/>
+      <arg name="font_name" type="s" direction="in"/>
+      <arg name="point_size" type="i" direction="in"/>
     </method>
     <method name="setSize">
       <arg name="columns" type="i" direction="in"/>

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -24,6 +24,7 @@
 #include <QAbstractButton>
 #include <QMouseEvent>
 #include <QGraphicsEffect>
+#include <QWindow>
 #include <cassert>
 
 #ifdef HAVE_QDBUS
@@ -407,6 +408,14 @@ void TermWidget::term_termLostFocus()
 {
     m_border = palette().color(QPalette::Window);
     update();
+}
+
+bool TermWidget::isExposed() const
+{
+    bool visible = isVisible();
+    if (visible && window()->windowHandle())
+        visible = window()->windowHandle()->isExposed(); // for wayland and minimized windows
+    return visible;
 }
 
 void TermWidget::paintEvent (QPaintEvent *)

--- a/src/termwidget.cpp
+++ b/src/termwidget.cpp
@@ -462,6 +462,13 @@ QDBusObjectPath TermWidget::getTab()
     return findParent<TermWidgetHolder>(this)->getDbusPath();
 }
 
+void TermWidget::activateTerminal()
+{
+    TermWidgetHolder *holder = findParent<TermWidgetHolder>(this);
+    holder->activateTab();
+    setFocus(Qt::OtherFocusReason);
+}
+
 void TermWidget::closeTerminal()
 {
     TermWidgetHolder *holder = findParent<TermWidgetHolder>(this);

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -92,6 +92,7 @@ class TermWidget : public QWidget, public DBusAddressable
         QDBusObjectPath splitVertical(const QString &dbus_id, const QString &shell_command, const QString &workdir, const int newPercent);
         QDBusObjectPath getTab();
         void sendText(const QString& text);
+        void activateTerminal();
         void closeTerminal();
         void setColorScheme(const QString& scheme);
         void setBackgroundImage(const QString &image, const int mode);

--- a/src/termwidget.h
+++ b/src/termwidget.h
@@ -84,6 +84,7 @@ class TermWidget : public QWidget, public DBusAddressable
         QStringList availableKeyBindings() { return m_term->availableKeyBindings(); }
 
         TermWidgetImpl * impl() { return m_term; }
+        bool isExposed() const;
 
         #ifdef HAVE_QDBUS
         QDBusObjectPath splitHorizontal(const QHash<QString,QVariant> &termArgs);

--- a/src/termwidgetholder.cpp
+++ b/src/termwidgetholder.cpp
@@ -452,6 +452,11 @@ QDBusObjectPath TermWidgetHolder::getWindow()
     return findParent<MainWindow>(this)->getDbusPath();
 }
 
+void TermWidgetHolder::activateTab()
+{
+    findParent<QTabWidget>(this)->setCurrentWidget(this);
+}
+
 void TermWidgetHolder::closeTab()
 {
     QTabWidget *parent = findParent<QTabWidget>(this);

--- a/src/termwidgetholder.h
+++ b/src/termwidgetholder.h
@@ -71,6 +71,7 @@ class TermWidgetHolder : public QWidget
         QDBusObjectPath getActiveTerminal();
         QList<QDBusObjectPath> getTerminals();
         QDBusObjectPath getWindow();
+        void activateTab();
         void closeTab();
         void setLabel(const QString &label);
         #endif


### PR DESCRIPTION
1. unminimize windows before trying to activate them (at least fluxbox doesn't allow to activate minimized windows)
2. shell clients/scripts might be interested in activating existing tabs (ie. themselves)
3. expose the window state via dbus to allow clients to query whether this is the active window w/o relying on xdotool or proprietary wayland compositor channels (swaymsg/niri msg/…) and be better at it
4. copypasta clean-up (functionally irrelevant but qdbus and the auto-completers show those and the false labels are irritating)
5. make the exit dialog (warning about a running process) window modal to not block all other windows in the same process